### PR TITLE
crypto_box: bump `chacha20poly1305` to v0.9; `xsalsa20poly1305` to v0.8

### DIFF
--- a/.github/workflows/crypto_box.yml
+++ b/.github/workflows/crypto_box.yml
@@ -17,33 +17,33 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
-#  # TODO: test no_std builds when rust-lang/cargo#7916 is on stable
-#  build:
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix:
-#        rust:
-#          - 1.49.0 # MSRV
-#          - stable
-#        target:
-#          - thumbv7em-none-eabi
-#          - wasm32-unknown-unknown
-#    steps:
-#      - uses: actions/checkout@v1
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: ${{ matrix.rust }}
-#          target: ${{ matrix.target }}
-#          override: true
-#      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.51.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features u32_backend
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features u32_backend,heapless
 
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.49.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -53,37 +53,4 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - run: cargo test --release
-
-  # TODO(tarcieri): re-unify this with `test` when MSRV is 1.51+
-  heapless:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.51.0 # MSRV for `heapless`
-          - stable
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
       - run: cargo test --release --features heapless
-
-  clippy:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.49.0 # MSRV
-          - stable
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          components: clippy
-          override: true
-      - run: cargo clippy -- -D warnings

--- a/.github/workflows/crypto_secretstream.yml
+++ b/.github/workflows/crypto_secretstream.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.49.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.49.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -52,37 +52,4 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - run: cargo test --release
-
-  # TODO(tarcieri): re-unify this with `test` when MSRV is 1.51+
-  heapless:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.51.0 # MSRV for `heapless`
-          - stable
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - run: cargo test --release --features heapless
-
-  clippy:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.49.0 # MSRV
-          - stable
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          components: clippy
-          override: true
-      - run: cargo clippy -- -D warnings
+      - run: cargo test --release --all-features

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -33,9 +33,8 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.49.0 # MSRV (highest in repo)
+          toolchain: 1.51.0
           components: clippy
           override: true
           profile: minimal
-      # TODO: add tests for features
       - run: cargo clippy --all -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,30 +14,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30302dda7a66f8c55932ebf208f7def840743ff64d495e9ceffcd97c18f11d39"
-dependencies = [
- "cortex-m",
-]
-
-[[package]]
-name = "bare-metal"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
-name = "bitfield"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
-
-[[package]]
 name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,9 +39,20 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8756167ea0aca10e066cdbe7813bd71d2f24e69b0bc7b50509590cef2ce0b9"
+checksum = "f08493fa7707effc63254c66c6ea908675912493cd67952eda23c09fae2610b1"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c5d87765c99be3d2cb08d11a3c14820ecaf2c7ad45d301c533103d2d8a146c"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -75,12 +62,12 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175a11316f33592cf2b71416ee65283730b5b7849813c4891d02a12906ed9acc"
+checksum = "3b84ed6d1d5f7aa9bdde921a5090e0ca4d934d250ea3b402a5fab3a994e28a2a"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.8.0",
  "cipher",
  "poly1305",
  "zeroize",
@@ -96,22 +83,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cortex-m"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac919ef424449ec8c08d515590ce15d9262c0ca5f0da5b0c901e971a3b783b3"
-dependencies = [
- "bare-metal",
- "bitfield",
- "embedded-hal",
- "volatile-register",
-]
-
-[[package]]
 name = "cpufeatures"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
 ]
@@ -120,7 +95,7 @@ dependencies = [
 name = "crypto_box"
 version = "0.6.1"
 dependencies = [
- "chacha20",
+ "chacha20 0.8.0",
  "chacha20poly1305",
  "rand_core 0.6.3",
  "salsa20",
@@ -134,7 +109,7 @@ name = "crypto_secretstream"
 version = "0.1.0"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.7.3",
  "getrandom",
  "poly1305",
  "rand_core 0.6.3",
@@ -144,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639891fde0dbea823fc3d798a0fdf9d2f9440a42d64a78ab3488b0ca025117b3"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
  "digest",
@@ -171,16 +146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
 dependencies = [
  "signature",
-]
-
-[[package]]
-name = "embedded-hal"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db184d3fa27bc7a2344250394c0264144dfe0bc81a4401801dcb964b8dd172ad"
-dependencies = [
- "nb 0.1.3",
- "void",
 ]
 
 [[package]]
@@ -217,11 +182,10 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e26526e7168021f34243a3c8faac4dc4f938cde75a0f9b8e373cca5eb4e7ce"
+checksum = "50530280e9a947b192e3a30a9d7bcead527b22da30ff7cbd334233d820aaf82a"
 dependencies = [
- "atomic-polyfill",
  "hash32",
  "stable_deref_trait",
 ]
@@ -243,9 +207,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libsodium-sys"
@@ -269,21 +233,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nb"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
-dependencies = [
- "nb 1.0.0",
-]
-
-[[package]]
-name = "nb"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
-
-[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,9 +246,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "poly1305"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fcffab1f78ebbdf4b93b68c1ffebc24037eedf271edaca795732b24e5e4e349"
+checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
@@ -308,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -340,19 +289,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "salsa20"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
+checksum = "0c0fbb5f676da676c260ba276a8f43a8dc67cf02d1438423aeb1c677a7212686"
 dependencies = [
  "cipher",
  "zeroize",
@@ -368,25 +308,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "serde"
-version = "1.0.127"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 
 [[package]]
 name = "signature"
@@ -420,9 +345,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -464,31 +389,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcell"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
-
-[[package]]
 name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "volatile-register"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
-dependencies = [
- "vcell",
-]
 
 [[package]]
 name = "walkdir"
@@ -605,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0f69b133860e3614a4d4fdd6f0d7fe3219e9d67a7e8cd537676a4ebc8313db"
+checksum = "e68bcb965d6c650091450b95cea12f07dcd299a01c15e2f9433b0813ea3c0886"
 dependencies = [
  "aead",
  "poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "crypto_box",
     "crypto_secretstream",

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -17,21 +17,13 @@ categories = ["cryptography", "no-std"]
 keywords = ["nacl", "libsodium", "public-key", "x25519", "xsalsa20poly1305"]
 
 [dependencies]
-chacha20 = { version = "0.7.1", features = ["expose-core", "hchacha"] }
+chacha20 = { version = "0.8", features = ["expose-core", "hchacha"] }
+chacha20poly1305 = { version = "0.9", default-features = false }
 rand_core = "0.6"
-salsa20 = { version = "0.8", features = ["hsalsa20"] }
+salsa20 = { version = "0.9", features = ["hsalsa20"] }
 x25519-dalek = { version = "1", default-features = false }
-zeroize = { version = "=1.3", default-features = false }
-
-[dependencies.chacha20poly1305]
-version = "0.8"
-default-features = false
-features = ["xchacha20poly1305"]
-
-[dependencies.xsalsa20poly1305]
-version = "0.7"
-default-features = false
-features = ["rand_core"]
+xsalsa20poly1305 = { version = "0.8", default-features = false, features = ["rand_core"] }
+zeroize = { version = ">=1, <1.5", default-features = false }
 
 [dev-dependencies]
 rand_core = { version = "0.6", features = ["std"] }

--- a/crypto_secretstream/README.md
+++ b/crypto_secretstream/README.md
@@ -43,13 +43,14 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/crypto_secretstream/badge.svg
 [docs-link]: https://docs.rs/crypto_secretstream/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [codecov-image]: https://codecov.io/gh/RustCrypto/AEADs/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/RustCrypto/AEADs
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260038-AEADs
 [build-image]: https://github.com/RustCrypto/AEADs/workflows/crypto_secretstream/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/AEADs/actions
+
 [//]: # "general links"
 [libsodium]: https://doc.libsodium.org/
 [`crypto_secretstream`]: https://libsodium.gitbook.io/doc/secret-key_cryptography/secretstream

--- a/crypto_secretstream/src/stream.rs
+++ b/crypto_secretstream/src/stream.rs
@@ -86,7 +86,7 @@ impl Stream {
         associated_data: &[u8],
         tag_block: [u8; TAG_BLOCK_SIZE],
         ciphertext: &[u8],
-    ) -> Result<Output<Poly1305>> {
+    ) -> Output<Poly1305> {
         let mut mac = Poly1305::new(mac_key);
 
         // pad block error in libsodium, see 290197ba
@@ -114,7 +114,7 @@ impl Stream {
         last_blocks[size_block_offset..size_block_offset + MAC_BLOCK_SIZE]
             .copy_from_slice(&size_block);
 
-        Ok(mac.compute_unpadded(&last_blocks[..size_block_offset + MAC_BLOCK_SIZE]))
+        mac.compute_unpadded(&last_blocks[..size_block_offset + MAC_BLOCK_SIZE])
     }
 
     /// Rekey the stream, used internally in `update_state`.
@@ -254,7 +254,7 @@ impl AeadInPlace for Stream {
 
         // compute and append mac
         let mac_output =
-            Stream::compute_mac(&mac_key, associated_data, tag_block, &buffer[1..])?.into_bytes();
+            Stream::compute_mac(&mac_key, associated_data, tag_block, &buffer[1..]).into_bytes();
 
         Ok(mac_output)
     }
@@ -284,7 +284,7 @@ impl AeadInPlace for Stream {
 
         // compute mac and reject if not matching
         let mac_output =
-            Stream::compute_mac(&mac_key, associated_data, tag_block, &buffer[1..])?.into_bytes();
+            Stream::compute_mac(&mac_key, associated_data, tag_block, &buffer[1..]).into_bytes();
         if bool::from(!mac_output.ct_eq(mac)) {
             return Err(aead::Error);
         }


### PR DESCRIPTION
Also transitively bumps MSRV to 1.51+