### PR TITLE
crypto_box v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "chacha20 0.8.0",
  "chacha20poly1305",

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Pure Rust implementation of APIs from [NaCl]-family libraries
 
 | Name                                                                                               | Crates.io                                                                                                             | Documentation                                                                                          | MSRV |
 | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ---- |
-| [`crypto_box`](https://github.com/RustCrypto/nacl-compat/tree/master/crypto_box)                   | [![crates.io](https://img.shields.io/crates/v/crypto_box.svg)](https://crates.io/crates/crypto_box)                   | [![Documentation](https://docs.rs/crypto_box/badge.svg)](https://docs.rs/crypto_box)                   | 1.49 |
-| [`crypto_secretstream`](https://github.com/RustCrypto/nacl-compat/tree/master/crypto_secretstream) | [![crates.io](https://img.shields.io/crates/v/crypto_secretstream.svg)](https://crates.io/crates/crypto_secretstream) | [![Documentation](https://docs.rs/crypto_secretstream/badge.svg)](https://docs.rs/crypto_secretstream) | 1.49 |
+| [`crypto_box`](https://github.com/RustCrypto/nacl-compat/tree/master/crypto_box)                   | [![crates.io](https://img.shields.io/crates/v/crypto_box.svg)](https://crates.io/crates/crypto_box)                   | [![Documentation](https://docs.rs/crypto_box/badge.svg)](https://docs.rs/crypto_box)                   | 1.51 |
+| [`crypto_secretstream`](https://github.com/RustCrypto/nacl-compat/tree/master/crypto_secretstream) | [![crates.io](https://img.shields.io/crates/v/crypto_secretstream.svg)](https://crates.io/crates/crypto_secretstream) | [![Documentation](https://docs.rs/crypto_secretstream/badge.svg)](https://docs.rs/crypto_secretstream) | 1.51 |
 
 ## MSRV Policy
 

--- a/crypto_box/CHANGELOG.md
+++ b/crypto_box/CHANGELOG.md
@@ -4,60 +4,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2021-08-30)
+### Changed
+- MSRV 1.51 ([#8])
+- Bump `chacha20poly1305` to v0.9 ([#8])
+- Bump `xsalsa20poly1305` to v0.8 ([#8])
+
+[#8]: https://github.com/RustCrypto/nacl-compat/pull/8
+
 ## 0.6.1 (2021-07-20)
 ### Changed
-- Pin `zeroize` dependency to v1.3 ([#349])
-
-[#349]: https://github.com/RustCrypto/AEADs/pull/349
+- Pin `zeroize` dependency to v1.3
 
 ## 0.6.0 (2021-04-29)
 ### Changed
-- Bump `chacha20poly1305` crate dependency to v0.8 ([#290])
-- Bump `xsalsa20poly1305` crate dependency to v0.7 ([#291])
-- Bump `rand_core` crate dependency to v0.6 ([#292])
+- Bump `chacha20poly1305` crate dependency to v0.8
+- Bump `xsalsa20poly1305` crate dependency to v0.7
+- Bump `rand_core` crate dependency to v0.6
 
 ### SECURITY
-- Fix XChaCha20Poly1305 key derivation ([#295])
-
-[#290]: https://github.com/RustCrypto/AEADs/pull/290
-[#291]: https://github.com/RustCrypto/AEADs/pull/291
-[#292]: https://github.com/RustCrypto/AEADs/pull/292
-[#295]: https://github.com/RustCrypto/AEADs/pull/295
+- Fix XChaCha20Poly1305 key derivation
 
 ## 0.5.0 (2020-10-16)
 ### Added
-- `ChaChaBox` ([#225])
+- `ChaChaBox`
 
 ### Changed
-- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])
-- Bump `xsalsa20poly1305` dependency to v0.6 ([#229])
-
-[#229]: https://github.com/RustCrypto/AEADs/pull/229
-[#225]: https://github.com/RustCrypto/AEADs/pull/225
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate
+- Bump `xsalsa20poly1305` dependency to v0.6
 
 ## 0.4.0 (2020-09-17)
 ### Added
-- Optional `std` feature; disabled by default ([#217])
+- Optional `std` feature; disabled by default
 
 ### Changed
-- Upgrade `xsalsa20poly1305` to v0.5 ([#218])
-
-[#218]: https://github.com/RustCrypto/AEADs/pull/218
-[#217]: https://github.com/RustCrypto/AEADs/pull/217
+- Upgrade `xsalsa20poly1305` to v0.5
 
 ## 0.3.0 (2020-08-18)
 ### Changed
-- Bump `x25519-dalek` dependency to 1.0 ([#194])
-
-[#194]: https://github.com/RustCrypto/AEADs/pull/194
+- Bump `x25519-dalek` dependency to 1.0
 
 ## 0.2.0 (2020-06-06)
 ### Changed
-- Bump `aead` crate dependency to v0.3; MSRV 1.41+ ([#146])
-- Bump `xsalsa20poly1305` dependency to v0.4 ([#164])
-
-[#146]: https://github.com/RustCrypto/AEADs/pull/146
-[#164]: https://github.com/RustCrypto/AEADs/pull/164
+- Bump `aead` crate dependency to v0.3; MSRV 1.41+
+- Bump `xsalsa20poly1305` dependency to v0.4
 
 ## 0.1.0 (2020-02-25)
 - Initial release

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_box"
-version = "0.6.1"
+version = "0.7.0"
 description = """
 Pure Rust implementation of NaCl's crypto_box public-key authenticated
 encryption primitive which combines the X25519 Elliptic Curve Diffie-Hellman


### PR DESCRIPTION
### Changed
- MSRV 1.51 ([#8])
- Bump `chacha20poly1305` to v0.9 ([#8])
- Bump `xsalsa20poly1305` to v0.8 ([#8])

[#8]: https://github.com/RustCrypto/nacl-compat/pull/8