### PR TITLE
Add clarifying note to library example documentation

### DIFF
--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -32,6 +32,9 @@
 //!
 //! # Usage
 //!
+//! NOTE: The following examples assumes use of the `std`
+//! [feature](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features).
+//!
 //! ```rust
 //! # #[cfg(feature = "std")]
 //! # {


### PR DESCRIPTION
- Makes the dependency on the `std` feature clear
- Provides linkage to Cargo Reference section about selecting features
- Close #19 