### PR TITLE
crypto_box: Replace SecretKey::to_bytes with as_bytes

### DIFF
--- a/crypto_box/CHANGELOG.md
+++ b/crypto_box/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Add `SecretKey::as_bytes` ([#24])
+- Deprecate `SecretKey::to_bytes` ([#24])
+
+[#24]: https://github.com/RustCrypto/nacl-compat/pull/24
+
 ## 0.7.0 (2021-08-30)
 ### Changed
 - MSRV 1.51 ([#8])

--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -45,7 +45,7 @@
 //! //
 //!
 //! // Generate a random secret key.
-//! // NOTE: It can be serialized as bytes by calling `secret_key.to_bytes()`
+//! // NOTE: The secret key bytes can be accessed by calling `secret_key.as_bytes()`
 //! let mut rng = crypto_box::rand_core::OsRng;
 //! let alice_secret_key = SecretKey::generate(&mut rng);
 //!
@@ -235,9 +235,15 @@ impl SecretKey {
         PublicKey(x25519(self.0, X25519_BASEPOINT_BYTES))
     }
 
-    /// Get the serialized bytes for this [`SecretKey`]
+    #[deprecated(note = "use `as_bytes` instead")]
+    #[allow(missing_docs)]
     pub fn to_bytes(&self) -> [u8; KEY_SIZE] {
         self.0
+    }
+
+    /// Get a slice of the [`SecretKey`] bytes
+    pub fn as_bytes(&self) -> &[u8; KEY_SIZE] {
+        &self.0
     }
 }
 
@@ -264,8 +270,8 @@ impl Drop for SecretKey {
 pub struct PublicKey([u8; KEY_SIZE]);
 
 impl PublicKey {
-    /// Borrow this public key as bytes.
-    pub fn as_bytes(&self) -> &[u8; 32] {
+    /// Get a slice of the [`PublicKey`] bytes
+    pub fn as_bytes(&self) -> &[u8; KEY_SIZE] {
         &self.0
     }
 }

--- a/crypto_box/tests/lib.rs
+++ b/crypto_box/tests/lib.rs
@@ -54,7 +54,7 @@ fn generate_secret_key() {
 #[test]
 fn secret_and_public_keys() {
     let secret_key = SecretKey::from(ALICE_SECRET_KEY);
-    assert_eq!(&secret_key.to_bytes(), &ALICE_SECRET_KEY);
+    assert_eq!(secret_key.as_bytes(), &ALICE_SECRET_KEY);
 
     // Ensure `Debug` impl on `SecretKey` is covered in tests
     dbg!(&secret_key);


### PR DESCRIPTION
This is consistent with the API for PublicKey. If one wants to copy the
byte array, the slice can be dereferenced.

Closes #23.