### PR TITLE
crypto_box: Add optional serde support

### DIFF
--- a/.github/workflows/crypto_box.yml
+++ b/.github/workflows/crypto_box.yml
@@ -54,3 +54,4 @@ jobs:
           override: true
       - run: cargo test --release --features std
       - run: cargo test --release --features std,heapless
+      - run: cargo test --release --features std,serde

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +131,7 @@ dependencies = [
  "chacha20poly1305",
  "rand",
  "rand_core 0.6.3",
+ "rmp-serde",
  "salsa20",
  "serde",
  "x25519-dalek",
@@ -307,6 +314,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +416,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f55e5fa1446c4d5dd1f5daeed2a4fe193071771a2636274d0d7a3b082aa7ad6"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723ecff9ad04f4ad92fe1c8ca6c20d2196d9286e9c60727c4cb5511629260e9d"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "blake2"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,10 +120,13 @@ dependencies = [
 name = "crypto_box"
 version = "0.7.0"
 dependencies = [
+ "bincode",
  "chacha20",
  "chacha20poly1305",
+ "rand",
  "rand_core 0.6.3",
  "salsa20",
+ "serde",
  "x25519-dalek",
  "xsalsa20poly1305",
  "zeroize",
@@ -318,6 +330,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +354,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.3",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +391,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom 0.2.3",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -34,6 +34,7 @@ default-features = false
 [dev-dependencies]
 bincode = "1"
 rand = "0.8"
+rmp-serde = "0.15"
 
 [features]
 default = ["alloc", "u64_backend"]

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -25,10 +25,25 @@ x25519-dalek = { version = "1", default-features = false }
 xsalsa20poly1305 = { version = "0.8", default-features = false, features = ["rand_core"] }
 zeroize = { version = ">=1, <1.5", default-features = false }
 
+[dependencies.serde_crate]
+package = "serde"
+optional = true
+version = "1"
+default-features = false
+
+[dev-dependencies]
+bincode = "1"
+rand = "0.8"
+
 [features]
 default = ["alloc", "u64_backend"]
+serde = ["serde_crate"]
 std = ["rand_core/std", "xsalsa20poly1305/std"]
 alloc = ["xsalsa20poly1305/alloc"]
 heapless = ["xsalsa20poly1305/heapless"]
 u32_backend = ["x25519-dalek/u32_backend"]
 u64_backend = ["x25519-dalek/u64_backend"]
+
+[package.metadata.docs.rs]
+features = ["serde"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -490,13 +490,21 @@ mod tests {
         // Create public key
         let public_key = PublicKey::from(public_key_bytes);
 
-        // Round-trip serialize
+        // Round-trip serialize with bincode
         let serialized =
             bincode::serialize(&public_key).expect("Public key could not be serialized");
         let deserialized: PublicKey =
             bincode::deserialize(&serialized).expect("Public key could not be deserialized");
+        assert_eq!(
+            deserialized, public_key,
+            "Deserialized public key does not match original"
+        );
 
-        // Deserialized public key should equal the original public key
+        // Round-trip serialize with rmp (msgpack)
+        let serialized =
+            rmp_serde::to_vec_named(&public_key).expect("Public key could not be serialized");
+        let deserialized: PublicKey =
+            rmp_serde::from_slice(&serialized).expect("Public key could not be deserialized");
         assert_eq!(
             deserialized, public_key,
             "Deserialized public key does not match original"

--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -309,7 +309,7 @@ impl Serialize for PublicKey {
     where
         S: Serializer,
     {
-        <[u8]>::serialize(&self.0, serializer)
+        serializer.serialize_bytes(&self.0)
     }
 }
 


### PR DESCRIPTION
The `serde` feature is optional, but enabled by default. (Could be made off-by-default if desired, not sure if we have a batteries-included or a minimal-by-default policy here.)

I used the serde-crate-alias trick, inspired by https://github.com/RustCrypto/RSA/pull/41

For a round-trip serialization test, I added "bincode" and "rand" dev-dependencies.