### PR TITLE
CI: Actually run crypto_box tests

### DIFF
--- a/.github/workflows/crypto_box.yml
+++ b/.github/workflows/crypto_box.yml
@@ -52,5 +52,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo test --release
-      - run: cargo test --release --features heapless
+      - run: cargo test --release --features std
+      - run: cargo test --release --features std,heapless


### PR DESCRIPTION
The crypto_box integration tests were gated on the `std` feature, which
was not enabled in CI. Thus none of these tests were actually run in CI.