### PR TITLE
crypto_box v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bincode",
  "chacha20",

--- a/crypto_box/CHANGELOG.md
+++ b/crypto_box/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-- Add `SecretKey::as_bytes` ([#24])
+## 0.7.1 (2022-01-12)
+### Added
+- `SecretKey::as_bytes` ([#24])
+- Optional `serde` support ([#27])
+
+### Changed
 - Deprecate `SecretKey::to_bytes` ([#24])
 
 [#24]: https://github.com/RustCrypto/nacl-compat/pull/24
+[#27]: https://github.com/RustCrypto/nacl-compat/pull/27
 
 ## 0.7.0 (2021-08-30)
 ### Changed

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_box"
-version = "0.7.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.7.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of NaCl's crypto_box public-key authenticated
 encryption primitive which combines the X25519 Elliptic Curve Diffie-Hellman

--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -186,7 +186,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/crypto_box/0.7.0"
+    html_root_url = "https://docs.rs/crypto_box/0.7.1"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 


### PR DESCRIPTION
### Added
- `SecretKey::as_bytes` ([#24])
- Optional `serde` support ([#27])

### Changed
- Deprecate `SecretKey::to_bytes` ([#24])

[#24]: https://github.com/RustCrypto/nacl-compat/pull/24
[#27]: https://github.com/RustCrypto/nacl-compat/pull/27