### PR TITLE
Fix building on docs.rs

### DIFF
--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -189,6 +189,7 @@
     html_root_url = "https://docs.rs/crypto_box/0.7.1"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use rand_core;
 pub use xsalsa20poly1305::{aead, generate_nonce};


### PR DESCRIPTION
We were missing a crate attribute for the doc_cfg feature. Without this, the docs on docs.rs cannot be built:

https://docs.rs/crate/crypto_box/0.7.1/builds/491318

To test this locally, this seems to do the trick:

    cargo +nightly rustdoc --features serde -Z unstable-options --config 'build.rustdocflags=["--cfg", "docsrs"]'