### PR TITLE
crypto_box: add v0.7.2 CHANGELOG.md entry

### DIFF
--- a/crypto_box/CHANGELOG.md
+++ b/crypto_box/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.2 (2022-03-21)
+### Fixed
+- Building on docs.rs ([#30])
+
+[#30]: https://github.com/RustCrypto/nacl-compat/pull/30
+
 ## 0.7.1 (2022-01-12)
 ### Added
 - `SecretKey::as_bytes` ([#24])


### PR DESCRIPTION
This was retroactively released as of the changes in #30. However, there are other changes on `master`, so this commit only includes the CHANGELOG.md entry.

The `crypto_box-v0.7.2` tag shows the commit history:

https://github.com/RustCrypto/nacl-compat/tree/crypto_box-v0.7.2