### PR TITLE
crypto_box: Bump chacha20poly1305 and xsalsa20poly1305

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,20 +77,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
- "zeroize",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fc89c7c5b9e7a02dfe45cd2367bae382f9ed31c61ca8debe5f827c420a2f08"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.3",
+ "cpufeatures",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.9.0"
+version = "0.10.0-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b84ed6d1d5f7aa9bdde921a5090e0ca4d934d250ea3b402a5fab3a994e28a2a"
+checksum = "746c430f71e66469abcf493c11484b1a86b957c84fc2d0ba664cd12ac23679ea"
 dependencies = [
  "aead",
- "chacha20",
- "cipher",
+ "chacha20 0.9.0",
+ "cipher 0.4.3",
  "poly1305",
  "zeroize",
 ]
@@ -102,6 +112,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -128,12 +149,12 @@ name = "crypto_box"
 version = "0.8.0-pre"
 dependencies = [
  "bincode",
- "chacha20",
+ "chacha20 0.8.1",
  "chacha20poly1305",
  "rand",
  "rand_core 0.6.3",
  "rmp-serde",
- "salsa20",
+ "salsa20 0.9.0",
  "serde",
  "x25519-dalek",
  "xsalsa20poly1305",
@@ -157,7 +178,7 @@ name = "crypto_secretstream"
 version = "0.1.0-pre"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.8.1",
  "getrandom 0.2.6",
  "poly1305",
  "rand_core 0.6.3",
@@ -167,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -260,6 +281,15 @@ dependencies = [
  "hash32",
  "spin",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -442,8 +472,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c0fbb5f676da676c260ba276a8f43a8dc67cf02d1438423aeb1c677a7212686"
 dependencies = [
- "cipher",
- "zeroize",
+ "cipher 0.3.0",
+]
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher 0.4.3",
 ]
 
 [[package]]
@@ -681,9 +719,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "x25519-dalek"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
+checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
@@ -693,23 +731,23 @@ dependencies = [
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.8.0"
+version = "0.9.0-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68bcb965d6c650091450b95cea12f07dcd299a01c15e2f9433b0813ea3c0886"
+checksum = "cbba873b4299e6d69907150936b2fff6982c2765416105f1f8b1e4aae9f51ddd"
 dependencies = [
  "aead",
  "poly1305",
  "rand_core 0.6.3",
- "salsa20",
+ "salsa20 0.10.2",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
 dependencies = [
  "zeroize_derive",
 ]

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -19,11 +19,11 @@ rust-version = "1.56"
 
 [dependencies]
 chacha20 = { version = "0.8", features = ["expose-core", "hchacha"] }
-chacha20poly1305 = { version = "0.9", default-features = false }
+chacha20poly1305 = { version = "=0.10.0-pre", default-features = false }
 rand_core = "0.6"
 salsa20 = { version = "0.9", features = ["hsalsa20"] }
 x25519-dalek = { version = "1", default-features = false }
-xsalsa20poly1305 = { version = "0.8", default-features = false, features = ["rand_core"] }
+xsalsa20poly1305 = { version = "=0.9.0-pre", default-features = false, features = ["rand_core"] }
 zeroize = { version = "1", default-features = false }
 
 [dependencies.serde_crate]


### PR DESCRIPTION
0.10.0-pre and 0.9.0-pre, respectively, relax the zeroize requirement.