### PR TITLE
crypto_box: use `serdect` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,7 +151,7 @@ dependencies = [
  "rand_core 0.6.3",
  "rmp-serde",
  "salsa20",
- "serde",
+ "serdect",
  "x25519-dalek",
  "xsalsa20poly1305",
  "zeroize",
@@ -499,6 +505,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serdect"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038fce1bf4d74b9b30ea7dcd59df75ba8ec669a5dcb3cc64fbfcef7334ced32c"
+dependencies = [
+ "base16ct",
+ "serde",
 ]
 
 [[package]]

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -26,11 +26,8 @@ x25519-dalek = { version = "1", default-features = false }
 xsalsa20poly1305 = { version = "0.9", default-features = false, features = ["rand_core"] }
 zeroize = { version = "1", default-features = false }
 
-[dependencies.serde_crate]
-package = "serde"
-optional = true
-version = "1"
-default-features = false
+# optional dependencies
+serdect = { version = "0.1", optional = true, default-features = false }
 
 [dev-dependencies]
 bincode = "1"
@@ -39,7 +36,7 @@ rmp-serde = "1"
 
 [features]
 default = ["alloc", "u64_backend"]
-serde = ["serde_crate"]
+serde = ["serdect"]
 std = ["rand_core/std", "xsalsa20poly1305/std"]
 alloc = ["xsalsa20poly1305/alloc"]
 heapless = ["xsalsa20poly1305/heapless"]


### PR DESCRIPTION
Replaces the handwritten serde visitor implementation with the same-shaped implementation in the `serdect` crate.

This reduces the maintenance burden of `serde`-related code, by keeping all of the complexity and interop testing in the `serdect` crate.