### PR TITLE
crypto_box: add direct `aead` dependency and use it for features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aead"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae06cea71059b6b79d879afcdd237a33ac61afc052fdd605815e6f3916254abf"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
 dependencies = [
  "crypto-common",
  "generic-array",
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d6e4974f4531e7674f7bde1fdda79802e5151e7a87580b7a282403f1648f75"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
  "chacha20",
@@ -144,11 +144,11 @@ dependencies = [
 name = "crypto_box"
 version = "0.8.0-pre"
 dependencies = [
+ "aead",
  "bincode",
  "chacha20",
  "chacha20poly1305",
  "rand",
- "rand_core 0.6.3",
  "rmp-serde",
  "salsa20",
  "serdect",

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -18,9 +18,9 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
+aead = { version = "0.5.1", default-features = false }
 chacha20 = "0.9"
-chacha20poly1305 = { version = "0.10", default-features = false }
-rand_core = "0.6"
+chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["rand_core"] }
 salsa20 = "0.10"
 x25519-dalek = { version = "1", default-features = false }
 xsalsa20poly1305 = { version = "0.9", default-features = false, features = ["rand_core"] }
@@ -35,11 +35,13 @@ rand = "0.8"
 rmp-serde = "1"
 
 [features]
-default = ["alloc", "u64_backend"]
+default = ["alloc", "getrandom", "u64_backend"]
+std = ["aead/std"]
 serde = ["serdect"]
-std = ["rand_core/std", "xsalsa20poly1305/std"]
-alloc = ["xsalsa20poly1305/alloc"]
-heapless = ["xsalsa20poly1305/heapless"]
+alloc = ["aead/alloc"]
+getrandom = ["aead/getrandom", "rand_core"]
+heapless = ["aead/heapless"]
+rand_core = ["aead/rand_core"]
 u32_backend = ["x25519-dalek/u32_backend"]
 u64_backend = ["x25519-dalek/u64_backend"]
 

--- a/crypto_box/tests/lib.rs
+++ b/crypto_box/tests/lib.rs
@@ -3,10 +3,12 @@
 //! Adapted from PHP Sodium Compat's test vectors:
 //! <https://www.phpclasses.org/browse/file/122796.html>
 
-#![cfg(feature = "std")]
+#![cfg(all(feature = "getrandom", feature = "std"))]
 
-use crypto_box::aead::{generic_array::GenericArray, Aead, AeadInPlace, Payload};
-use crypto_box::{ChaChaBox, PublicKey, SalsaBox, SecretKey};
+use crypto_box::{
+    aead::{generic_array::GenericArray, Aead, AeadInPlace, OsRng, Payload},
+    ChaChaBox, PublicKey, SalsaBox, SecretKey,
+};
 use std::any::TypeId;
 
 // Alice's keypair
@@ -48,7 +50,7 @@ const PLAINTEXT: &[u8] = &[
 
 #[test]
 fn generate_secret_key() {
-    SecretKey::generate(&mut rand_core::OsRng);
+    SecretKey::generate(&mut OsRng);
 }
 
 #[test]


### PR DESCRIPTION
Activates crate features transitively through the `aead` crate