### PR TITLE
CI: fix security audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,2 @@
+[advisories]
+ignore = ["RUSTSEC-2021-0137"]


### PR DESCRIPTION
`sodiumoxide` is unmaintained, however we still use it for interop testing