### PR TITLE
crypto_box: select `x25519-dalek` backend automatically

### DIFF
--- a/.github/workflows/crypto_box.yml
+++ b/.github/workflows/crypto_box.yml
@@ -35,8 +35,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features u32_backend
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features u32_backend,heapless
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features heapless
 
   test:
     runs-on: ubuntu-latest
@@ -52,6 +52,6 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo test --release --features std
-      - run: cargo test --release --features std,heapless
-      - run: cargo test --release --features std,serde
+      - run: cargo test --release --no-default-features
+      - run: cargo test --release
+      - run: cargo test --release --all-features

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -22,9 +22,14 @@ aead = { version = "0.5.1", default-features = false }
 chacha20 = "0.9"
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["rand_core"] }
 salsa20 = "0.10"
-x25519-dalek = { version = "1", default-features = false }
 xsalsa20poly1305 = { version = "0.9", default-features = false, features = ["rand_core"] }
 zeroize = { version = "1", default-features = false }
+
+[target.'cfg(target_pointer_width = "32")'.dependencies]
+x25519-dalek = { version = "1", default-features = false, features = ["u32_backend"] }
+
+[target.'cfg(target_pointer_width = "64")'.dependencies]
+x25519-dalek = { version = "1", default-features = false, features = ["u64_backend"] }
 
 # optional dependencies
 serdect = { version = "0.1", optional = true, default-features = false }
@@ -35,16 +40,14 @@ rand = "0.8"
 rmp-serde = "1"
 
 [features]
-default = ["alloc", "getrandom", "u64_backend"]
+default = ["alloc", "getrandom"]
 std = ["aead/std"]
-serde = ["serdect"]
 alloc = ["aead/alloc"]
 getrandom = ["aead/getrandom", "rand_core"]
 heapless = ["aead/heapless"]
 rand_core = ["aead/rand_core"]
-u32_backend = ["x25519-dalek/u32_backend"]
-u64_backend = ["x25519-dalek/u64_backend"]
+serde = ["serdect"]
 
 [package.metadata.docs.rs]
-features = ["serde"]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -190,13 +190,15 @@
 //! [`heapless::Vec`]: https://docs.rs/heapless/latest/heapless/struct.Vec.html
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/crypto_box/0.7.1"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+
+#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
+compile_error!("`crypto-box` requires either a 32-bit or 64-bit target");
 
 pub use aead::{self, rand_core};
 pub use xsalsa20poly1305::Nonce;


### PR DESCRIPTION
Introspects the target pointer width to automatically select either the `u32_backend` or `u64_backend`.

If the backend isn't 32/64-bit, generate a compile error with an informative message.

Removes the explicit `u32_backend`/`u64_backend` crate features in `cargo_box` itself. Now `--all-features` works.