### PR TITLE
crypto_box v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.8.0-pre"
+version = "0.8.0"
 dependencies = [
  "aead",
  "bincode",

--- a/crypto_box/CHANGELOG.md
+++ b/crypto_box/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2022-08-10)
+### Changed
+- Unpin `zeroize` version ([#41])
+- Upgrade to Rust 2021 edition; MSRV 1.56 ([#42])
+- Bump `chacha20` to v0.9 ([#50])
+- Bump `chacha20poly1305` to v0.10 ([#50])
+- Use `serdect` crate ([#51])
+- Select `x25519-dalek` backend automatically ([#55])
+
+### Removed
+- `Box` type alias: use `SalsaBox` instead ([#53])
+- `u32_backend` and `u64_backend` features: now selected automatically ([#55])
+
+[#41]: https://github.com/RustCrypto/nacl-compat/pull/41
+[#42]: https://github.com/RustCrypto/nacl-compat/pull/42
+[#50]: https://github.com/RustCrypto/nacl-compat/pull/50
+[#51]: https://github.com/RustCrypto/nacl-compat/pull/51
+[#53]: https://github.com/RustCrypto/nacl-compat/pull/53
+[#55]: https://github.com/RustCrypto/nacl-compat/pull/55
+
 ## 0.7.2 (2022-03-21)
 ### Fixed
 - Building on docs.rs ([#30])

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_box"
-version = "0.8.0-pre"
+version = "0.8.0"
 description = """
 Pure Rust implementation of NaCl's crypto_box public-key authenticated
 encryption primitive which combines the X25519 Elliptic Curve Diffie-Hellman


### PR DESCRIPTION
### Changed
- Unpin `zeroize` version ([#41])
- Upgrade to Rust 2021 edition; MSRV 1.56 ([#42])
- Bump `chacha20` to v0.9 ([#50])
- Bump `chacha20poly1305` to v0.10 ([#50])
- Use `serdect` crate ([#51])
- Select `x25519-dalek` backend automatically ([#55])

### Removed
- `Box` type alias: use `SalsaBox` instead ([#53])
- `u32_backend` and `u64_backend` features: now selected automatically ([#55])

[#41]: https://github.com/RustCrypto/nacl-compat/pull/41
[#42]: https://github.com/RustCrypto/nacl-compat/pull/42
[#50]: https://github.com/RustCrypto/nacl-compat/pull/50
[#51]: https://github.com/RustCrypto/nacl-compat/pull/51
[#53]: https://github.com/RustCrypto/nacl-compat/pull/53
[#55]: https://github.com/RustCrypto/nacl-compat/pull/55