### PR TITLE
crypto_kx: use `serdect` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
  "blake2",
  "getrandom 0.2.7",
  "rand_core 0.6.3",
- "serde",
+ "serdect",
  "sodiumoxide",
  "x25519-dalek",
 ]
@@ -191,7 +191,6 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
- "serde",
  "subtle",
  "zeroize",
 ]
@@ -492,20 +491,6 @@ name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.136"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "serdect"
@@ -723,7 +708,6 @@ checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
- "serde",
  "zeroize",
 ]
 

--- a/crypto_kx/Cargo.toml
+++ b/crypto_kx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_kx"
-version = "0.1.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.0-pre"
 description = "Pure Rust implementation of libsodium's crypto_kx using BLAKE2"
 authors = ["C4DT", "RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -16,8 +16,9 @@ rust-version = "1.56"
 [dependencies]
 blake2 = { version = "0.10", default-features = false }
 rand_core = "0.6"
-# renamed to allow having a "serde" feature
-our_serde = { package = "serde", version = "1", optional = true, features = ["derive"] }
+
+# optional dependencies
+serdect = { version = "0.1", optional = true, default-features = false }
 
 [dependencies.x25519-dalek]
 version = "1"
@@ -32,5 +33,5 @@ rand_core = { version = "0.6", features = ["std"] }
 sodiumoxide = "0.2"
 
 [features]
-serde = ["our_serde", "x25519-dalek/serde"]
+serde = ["serdect"]
 std = ["blake2/std", "rand_core/std", "x25519-dalek/std"]

--- a/crypto_kx/src/keypair.rs
+++ b/crypto_kx/src/keypair.rs
@@ -4,12 +4,6 @@ use rand_core::{CryptoRng, RngCore};
 use crate::{ClientSessionKeys, PublicKey, SecretKey, ServerSessionKeys, SessionKey};
 
 /// A [`SecretKey`] with its related [`PublicKey`].
-#[derive(Clone)]
-#[cfg_attr(
-    feature = "serde",
-    derive(our_serde::Deserialize, our_serde::Serialize)
-)]
-#[cfg_attr(feature = "serde", serde(crate = "our_serde"))]
 pub struct KeyPair {
     secret: SecretKey,
     public: PublicKey,

--- a/crypto_kx/src/keys/secret.rs
+++ b/crypto_kx/src/keys/secret.rs
@@ -3,13 +3,11 @@
 use crate::errors::InvalidLength;
 use rand_core::{CryptoRng, RngCore};
 
+#[cfg(feature = "serde")]
+use serdect::serde::{de, ser, Deserialize, Serialize};
+
 /// [`SecretKey`] that should be kept private.
 #[derive(Clone)]
-#[cfg_attr(
-    feature = "serde",
-    derive(our_serde::Deserialize, our_serde::Serialize)
-)]
-#[cfg_attr(feature = "serde", serde(crate = "our_serde"))]
 pub struct SecretKey(x25519_dalek::StaticSecret);
 
 impl SecretKey {
@@ -54,5 +52,27 @@ impl TryFrom<&[u8]> for SecretKey {
         array.copy_from_slice(slice);
 
         Ok(Self::from(array))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for SecretKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        serdect::array::serialize_hex_upper_or_bin(&self.0.to_bytes(), serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for SecretKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let mut bytes = [0u8; Self::BYTES];
+        serdect::array::deserialize_hex_or_bin(&mut bytes, deserializer)?;
+        Self::try_from(&bytes[..]).map_err(de::Error::custom)
     }
 }

--- a/crypto_kx/src/lib.rs
+++ b/crypto_kx/src/lib.rs
@@ -49,8 +49,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/crypto_kx/0.0.2"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 


### PR DESCRIPTION
Replaces the handwritten serde visitor implementation with the same-shaped implementation in the `serdect` crate, similar to the changes to the `crypto_box` crate in #51.

This reduces the maintenance burden of `serde`-related code, by keeping all of the complexity and interop testing in the `serdect` crate.