### PR TITLE
crypto_kx: select `x25519-dalek` backend automatically

### DIFF
--- a/crypto_kx/Cargo.toml
+++ b/crypto_kx/Cargo.toml
@@ -17,13 +17,14 @@ rust-version = "1.56"
 blake2 = { version = "0.10", default-features = false }
 rand_core = "0.6"
 
+[target.'cfg(target_pointer_width = "32")'.dependencies]
+x25519-dalek = { version = "1", default-features = false, features = ["u32_backend"] }
+
+[target.'cfg(target_pointer_width = "64")'.dependencies]
+x25519-dalek = { version = "1", default-features = false, features = ["u64_backend"] }
+
 # optional dependencies
 serdect = { version = "0.1", optional = true, default-features = false }
-
-[dependencies.x25519-dalek]
-version = "1"
-default-features = false
-features = ["u64_backend"] # to allow --no-default-features
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2", default-features = false, features = ["js"] }

--- a/crypto_kx/README.md
+++ b/crypto_kx/README.md
@@ -11,6 +11,25 @@ Pure Rust implementation of [libsodium]'s [`crypto_kx`] primitive.
 
 [Documentation][docs-link]
 
+## About
+
+Imagine Alice wants to open a safe communication channel with Betty,
+using something like [`crypto_secretstream`]. They first need to agree on
+a shared secret.
+
+To obtain this shared secret, Diffie-Hellman can be used, which works as follows:
+Suppose both Alice and Betty know the public key of each other.
+Then they use their private key and the other's public key to generate a
+secret. This secret is the same for both Alice and Betty, as described by
+the Diffie-Hellman algorithm.
+No eavesdropper can know what the secret is, as they only know the public keys, but
+not the private keys.
+
+Using the same key for sending and receiving might pose cryptographic
+issues and/or reduce the overall throughput.
+So when computing the shared secret, you actually get two keys,
+one for each direction.
+
 ## License
 
 Licensed under either of:

--- a/crypto_kx/src/lib.rs
+++ b/crypto_kx/src/lib.rs
@@ -1,27 +1,11 @@
-//! Pure Rust implementation of the [`crypto_kx`] key exchange
-//! from [NaCl]-family libraries (e.g. libsodium, TweetNaCl)
-//! which uses [BLAKE2].
-//!
-//! # Introduction
-//!
-//! Imagine Alice wants to open a safe communication channel with Betty,
-//! using something like [`crypto_secretstream`]. They first need to agree on
-//! a shared secret.
-//!
-//! To obtain this shared secret, Diffie-Hellman can be used, which works as follows:
-//! Suppose both Alice and Betty know the public key of each other.
-//! Then they use their private key and the other's public key to generate a
-//! secret. This secret is the same for both Alice and Betty, as described by
-//! the Diffie-Hellman algorithm.
-//! No eavesdropper can know what the secret is, as they only know the public keys, but
-//! not the private keys.
-//!
-//! Using the same key for sending and receiving might pose cryptographic
-//! issues and/or reduce the overall throughput.
-//! So when computing the shared secret, you actually get two keys,
-//! one for each direction.
-//!
-//! # Usage
+#![no_std]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
+)]
+#![warn(missing_docs, rust_2018_idioms)]
+
+//! ## Usage
 //!
 //! ```rust
 //! use crypto_kx::*;
@@ -46,12 +30,8 @@
 //! [`crypto_secretstream`]: https://github.com/RustCrypto/nacl-compat/tree/master/crypto_secretstream
 //! [BLAKE2]: https://github.com/RustCrypto/hashes/tree/master/blake2
 
-#![no_std]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
-)]
-#![warn(missing_docs, rust_2018_idioms)]
+#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
+compile_error!("`crypto-box` requires either a 32-bit or 64-bit target");
 
 mod keypair;
 mod keys;


### PR DESCRIPTION
Introspects the target pointer width to automatically select either the `u32_backend` or `u64_backend`, similar to #55.

If the backend isn't 32/64-bit, generate a compile error with an informative message.