### PR TITLE
crypto_box v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aead",
  "bincode",

--- a/crypto_box/CHANGELOG.md
+++ b/crypto_box/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.8.0 (2022-08-10)
+## 0.8.1 (2022-08-15)
+### Changed
+- Revert "select `x25519-dalek` backend automatically" ([#63])
+
+[#63]: https://github.com/RustCrypto/nacl-compat/pull/63
+
+## 0.8.0 (2022-08-10) [YANKED]
+
+This release was yanked due to issues with automatically selecting the
+`x25519-dalek` backend. See [#55].
+
 ### Changed
 - Unpin `zeroize` version ([#41])
 - Upgrade to Rust 2021 edition; MSRV 1.56 ([#42])

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_box"
-version = "0.8.0"
+version = "0.8.1"
 description = """
 Pure Rust implementation of NaCl's crypto_box public-key authenticated
 encryption primitive which combines the X25519 Elliptic Curve Diffie-Hellman


### PR DESCRIPTION
### Changed
- Revert "select `x25519-dalek` backend automatically" ([#63])

[#63]: https://github.com/RustCrypto/nacl-compat/pull/63