### PR TITLE
crypto_box v0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "aead",
  "bincode",

--- a/crypto_box/CHANGELOG.md
+++ b/crypto_box/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.2 (2022-10-29)
+### Added
+- `seal` and `seal_open` functions ([#66])
+
+[#66]: https://github.com/RustCrypto/nacl-compat/pull/66
+
 ## 0.8.1 (2022-08-15)
 ### Changed
 - Revert "select `x25519-dalek` backend automatically" ([#63])

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_box"
-version = "0.8.1"
+version = "0.8.2"
 description = """
 Pure Rust implementation of NaCl's crypto_box public-key authenticated
 encryption primitive which combines the X25519 Elliptic Curve Diffie-Hellman


### PR DESCRIPTION
### Added
- `seal` and `seal_open` functions ([#66])

[#66]: https://github.com/RustCrypto/nacl-compat/pull/66