### PR TITLE
crypto_secretstream: Fix copy_with_slice expecting 8 bytes and WASM having 32bit usize 

### DIFF
--- a/crypto_secretstream/src/stream.rs
+++ b/crypto_secretstream/src/stream.rs
@@ -98,8 +98,9 @@ impl Stream {
 
         // compute size block
         let mut size_block = [0u8; MAC_BLOCK_SIZE];
-        size_block[..8].copy_from_slice(&associated_data.len().to_le_bytes());
-        size_block[8..].copy_from_slice(&(TAG_BLOCK_SIZE + ciphertext.len()).to_le_bytes());
+        size_block[..8].copy_from_slice(&(associated_data.len() as u64).to_le_bytes());
+        size_block[8..]
+            .copy_from_slice(&(TAG_BLOCK_SIZE as u64 + ciphertext.len() as u64).to_le_bytes());
 
         mac.update_padded(associated_data); // blind with associated data
         mac.update_padded(&tag_block); // do not any add padding


### PR DESCRIPTION
`len()` returns a `usize` which causes a WASM build of crypto_secretstream to fail with:

```
source slice length (4) does not match destination slice length (8)', crypto_secretstream/src/stream.rs:101`
```

With the below patch this problem is fixed. I believe this should be quite safe to merge (but not a Rust expert by no means).