### PR TITLE
crypto_secretstream v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_secretstream"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aead",
  "chacha20",

--- a/crypto_secretstream/CHANGELOG.md
+++ b/crypto_secretstream/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2022-12-01)
+### Fixed
+- WASM problem with 32-bit usize and `copy_with_slice` expecting 8-bytes ([#76])
+
+[#76]: https://github.com/RustCrypto/nacl-compat/pull/76
+
 ## 0.1.0 (2022-08-13)
 ### Changed
 - Bump `chacha20` to v0.9 ([#50])

--- a/crypto_secretstream/Cargo.toml
+++ b/crypto_secretstream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_secretstream"
-version = "0.1.0"
+version = "0.1.1"
 description = """
 Pure Rust implementation of libsodium's crypto_secretstream secret-key using
 ChaCha20 and Poly1305


### PR DESCRIPTION
### Fixed
- WASM problem with 32-bit usize and `copy_with_slice` expecting 8-bytes ([#76])

[#76]: https://github.com/RustCrypto/nacl-compat/pull/76