### PR TITLE
crypto_box: use `crypto_secretbox`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,12 +218,12 @@ dependencies = [
  "blake2",
  "chacha20",
  "chacha20poly1305",
+ "crypto_secretbox",
  "rand",
  "rmp-serde",
  "salsa20",
  "serdect",
  "x25519-dalek",
- "xsalsa20poly1305",
  "zeroize",
 ]
 
@@ -933,19 +933,6 @@ checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
- "zeroize",
-]
-
-[[package]]
-name = "xsalsa20poly1305"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "472c385ee974833d7e59979eeb74175d56774be3768b5bcc581337e21396bda3"
-dependencies = [
- "aead",
- "poly1305",
- "salsa20",
- "subtle",
  "zeroize",
 ]
 

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -21,9 +21,9 @@ rust-version = "1.56"
 aead = { version = "0.5.1", default-features = false }
 chacha20 = "0.9"
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["rand_core"] }
+crypto_secretbox = { version = "0", default-features = false, path = "../crypto_secretbox" }
 salsa20 = "0.10"
 x25519-dalek = { version = "1", default-features = false }
-xsalsa20poly1305 = { version = "0.9", default-features = false, features = ["rand_core"] }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies

--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -165,20 +165,20 @@
 //! [`heapless::Vec`]: https://docs.rs/heapless/latest/heapless/struct.Vec.html
 
 pub use aead::{self, rand_core};
-pub use xsalsa20poly1305::Nonce;
+pub use crypto_secretbox::Nonce;
 
-use chacha20::hchacha;
-use chacha20poly1305::XChaCha20Poly1305;
-use core::fmt::{self, Debug};
-use rand_core::{CryptoRng, RngCore};
-use salsa20::hsalsa;
-use x25519_dalek::{x25519, X25519_BASEPOINT_BYTES};
-use xsalsa20poly1305::aead::{
+use aead::{
     consts::{U0, U10, U16, U24},
     generic_array::GenericArray,
     AeadCore, AeadInPlace, Buffer, Error, KeyInit,
 };
-use xsalsa20poly1305::XSalsa20Poly1305;
+use chacha20::hchacha;
+use chacha20poly1305::XChaCha20Poly1305;
+use core::fmt::{self, Debug};
+use crypto_secretbox::XSalsa20Poly1305;
+use rand_core::{CryptoRng, RngCore};
+use salsa20::hsalsa;
+use x25519_dalek::{x25519, X25519_BASEPOINT_BYTES};
 use zeroize::{Zeroize, Zeroizing};
 
 #[cfg(feature = "seal")]

--- a/crypto_secretbox/README.md
+++ b/crypto_secretbox/README.md
@@ -52,8 +52,8 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260038-AEADs
-[build-image]: https://github.com/RustCrypto/AEADs/workflows/crypto_secretbox/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/AEADs/actions
+[build-image]: https://github.com/RustCrypto/nacl-compat/actions/workflows/crypto_secretbox.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/nacl-compat/actions/workflows/crypto_secretbox.yml
 
 [//]: # (general links)
 


### PR DESCRIPTION
Sources `XSalsa20Poly1305` from `crypto_secretbox` instead of the `xsalsa20poly1305` crate.

The longer-term goal is to make `XSalsa20Poly1305` generic around the stream cipher.