### PR TITLE
crypto_box: Derive Ord/PartialOrd for PublicKey

### DIFF
--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -257,7 +257,7 @@ impl Drop for SecretKey {
 /// A `crypto_box` public key.
 ///
 /// This type can be serialized if the `serde` feature is enabled.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct PublicKey([u8; KEY_SIZE]);
 
 impl PublicKey {


### PR DESCRIPTION
In some situations it makes sense to use public keys as identifiers. In that case, it's useful to be able to sort a list of public keys (e.g. to print them in correct order for diagnostic purposes).