### PR TITLE
crypto_box: use `curve25519-dalek`; MSRV 1.60

### DIFF
--- a/.github/workflows/crypto_box.yml
+++ b/.github/workflows/crypto_box.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -36,15 +36,15 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features u32_backend
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features u32_backend,heapless
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features heapless
 
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/crypto_kx.yml
+++ b/.github/workflows/crypto_kx.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/crypto_secretbox.yml
+++ b/.github/workflows/crypto_secretbox.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/crypto_secretstream.yml
+++ b/.github/workflows/crypto_secretstream.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.56.0
+          toolchain: 1.60.0
           components: clippy
           override: true
           profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.8.2"
+version = "0.9.0-pre"
 dependencies = [
  "aead",
  "bincode",
@@ -219,17 +219,17 @@ dependencies = [
  "chacha20",
  "chacha20poly1305",
  "crypto_secretbox",
+ "curve25519-dalek 4.0.0-rc.1",
  "rand",
  "rmp-serde",
  "salsa20",
  "serdect",
- "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
 name = "crypto_kx"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "blake2",
  "getrandom 0.2.8",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_secretstream"
-version = "0.1.1"
+version = "0.2.0-pre"
 dependencies = [
  "aead",
  "chacha20",
@@ -272,6 +272,20 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d4ba9852b42210c7538b75484f9daa0655e9a3ac04f693747bb0f02cf3cfe16"
+dependencies = [
+ "cfg-if",
+ "fiat-crypto",
+ "packed_simd_2",
+ "platforms",
  "subtle",
  "zeroize",
 ]
@@ -314,6 +328,12 @@ dependencies = [
  "nb 0.1.3",
  "void",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a214f5bb88731d436478f3ae1f8a277b62124089ba9fb67f4f93fb100ef73c90"
 
 [[package]]
 name = "generic-array"
@@ -403,6 +423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
+name = "libm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+
+[[package]]
 name = "libsodium-sys"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +502,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "packed_simd_2"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
+dependencies = [
+ "cfg-if",
+ "libm",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +522,12 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "platforms"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "poly1305"
@@ -931,7 +973,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 3.2.0",
  "rand_core 0.5.1",
  "zeroize",
 ]

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_box"
-version = "0.8.2"
+version = "0.9.0-pre"
 description = """
 Pure Rust implementation of NaCl's crypto_box public-key authenticated
 encryption primitive which combines the X25519 Elliptic Curve Diffie-Hellman
@@ -15,15 +15,15 @@ repository = "https://github.com/RustCrypto/nacl-compat/tree/master/crypto_box"
 categories = ["cryptography", "no-std"]
 keywords = ["nacl", "libsodium", "public-key", "x25519", "xsalsa20poly1305"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [dependencies]
 aead = { version = "0.5.1", default-features = false }
 chacha20 = "0.9"
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["rand_core"] }
 crypto_secretbox = { version = "0", default-features = false, path = "../crypto_secretbox" }
+curve25519-dalek = { version = "4.0.0-rc.1", default-features = false, features = ["zeroize"] }
 salsa20 = "0.10"
-x25519-dalek = { version = "1", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies
@@ -36,7 +36,7 @@ rand = "0.8"
 rmp-serde = "1"
 
 [features]
-default = ["alloc", "getrandom", "u64_backend"]
+default = ["alloc", "getrandom"]
 std = ["aead/std"]
 serde = ["serdect"]
 alloc = ["aead/alloc"]
@@ -44,8 +44,6 @@ getrandom = ["aead/getrandom", "rand_core"]
 heapless = ["aead/heapless"]
 rand_core = ["aead/rand_core"]
 seal = ["alloc", "blake2"]
-u32_backend = ["x25519-dalek/u32_backend"]
-u64_backend = ["x25519-dalek/u64_backend"]
 
 [package.metadata.docs.rs]
 features = ["serde", "seal"]

--- a/crypto_box/README.md
+++ b/crypto_box/README.md
@@ -68,7 +68,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/crypto_box/badge.svg
 [docs-link]: https://docs.rs/crypto_box/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260038-AEADs
 [build-image]: https://github.com/RustCrypto/nacl-compat/actions/workflows/crypto_box.yml/badge.svg

--- a/crypto_box/tests/lib.rs
+++ b/crypto_box/tests/lib.rs
@@ -56,7 +56,7 @@ fn generate_secret_key() {
 #[test]
 fn secret_and_public_keys() {
     let secret_key = SecretKey::from(ALICE_SECRET_KEY);
-    assert_eq!(secret_key.as_bytes(), &ALICE_SECRET_KEY);
+    assert_eq!(secret_key.to_bytes(), ALICE_SECRET_KEY);
 
     // Ensure `Debug` impl on `SecretKey` is covered in tests
     dbg!(&secret_key);

--- a/crypto_kx/Cargo.toml
+++ b/crypto_kx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_kx"
-version = "0.1.0"
+version = "0.2.0-pre"
 description = "Pure Rust implementation of libsodium's crypto_kx using BLAKE2"
 authors = ["C4DT", "RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -11,7 +11,7 @@ repository = "https://github.com/RustCrypto/nacl-compat/tree/master/crypto_kx"
 categories = ["cryptography", "no-std"]
 keywords = ["nacl", "libsodium", "public-key", "blake2"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [dependencies]
 blake2 = { version = "0.10", default-features = false }

--- a/crypto_kx/README.md
+++ b/crypto_kx/README.md
@@ -51,7 +51,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/crypto_kx/badge.svg
 [docs-link]: https://docs.rs/crypto_kx/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260038-AEADs
 [build-image]: https://github.com/RustCrypto/nacl-compat/actions/workflows/crypto_kx.yml/badge.svg

--- a/crypto_secretbox/Cargo.toml
+++ b/crypto_secretbox/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/crypto_secretbox"
 repository = "https://github.com/RustCrypto/nacl-compat/tree/master/crypto_secretbox"
 keywords = ["aead", "salsa20", "poly1305", "xsalsa20"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.56"
+rust-version = "1.60"
 
 [dependencies]
 aead = { version = "0.5", default-features = false }

--- a/crypto_secretbox/README.md
+++ b/crypto_secretbox/README.md
@@ -49,7 +49,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/crypto_secretbox/badge.svg
 [docs-link]: https://docs.rs/crypto_secretbox/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260038-AEADs
 [build-image]: https://github.com/RustCrypto/nacl-compat/actions/workflows/crypto_secretbox.yml/badge.svg

--- a/crypto_secretstream/Cargo.toml
+++ b/crypto_secretstream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_secretstream"
-version = "0.1.1"
+version = "0.2.0-pre"
 description = """
 Pure Rust implementation of libsodium's crypto_secretstream secret-key using
 ChaCha20 and Poly1305
@@ -14,7 +14,7 @@ repository = "https://github.com/RustCrypto/nacl-compat/tree/master/crypto_secre
 categories = ["cryptography"]
 keywords = ["nacl", "libsodium", "public-key", "chacha20", "poly1305"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [dependencies]
 aead = { version = "0.5", features = ["stream"] }

--- a/crypto_secretstream/README.md
+++ b/crypto_secretstream/README.md
@@ -64,7 +64,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/crypto_secretstream/badge.svg
 [docs-link]: https://docs.rs/crypto_secretstream/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260038-AEADs
 [build-image]: https://github.com/RustCrypto/nacl-compat/actions/workflows/crypto_secretstream.yml/badge.svg


### PR DESCRIPTION
Upgrades to the latest `curve25519-dalek` v4.0.0-rc.1 release.

The `x25519-dalek` crate is a wrapper whose functionality isn't really used, and we can use the `Scalar` and `MontgomeryPoint` types directly.