### PR TITLE
crypto_secretbox: make `salsa20` an optional dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ name = "crypto_secretbox"
 version = "0.0.0"
 dependencies = [
  "aead",
+ "cipher",
  "poly1305",
  "salsa20",
  "subtle",

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.60"
 aead = { version = "0.5.1", default-features = false }
 chacha20 = "0.9"
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["rand_core"] }
-crypto_secretbox = { version = "0", default-features = false, path = "../crypto_secretbox" }
+crypto_secretbox = { version = "0", default-features = false, features = ["salsa20"], path = "../crypto_secretbox" }
 curve25519-dalek = { version = "4.0.0-rc.1", default-features = false, features = ["zeroize"] }
 salsa20 = "0.10"
 zeroize = { version = "1", default-features = false }

--- a/crypto_secretbox/Cargo.toml
+++ b/crypto_secretbox/Cargo.toml
@@ -17,15 +17,19 @@ rust-version = "1.60"
 
 [dependencies]
 aead = { version = "0.5", default-features = false }
-salsa20 = { version = "0.10", features = ["zeroize"] }
+cipher = { version = "0.4", default-features = false }
 poly1305 = "0.8"
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
+# optional dependencies
+salsa20 = { version = "0.10", optional = true, features = ["zeroize"] }
+
 [features]
-default = ["alloc", "getrandom"]
-std = ["aead/std", "alloc"]
+default = ["alloc", "getrandom", "salsa20"]
 alloc = ["aead/alloc"]
+std = ["aead/std", "alloc"]
+
 getrandom  = ["aead/getrandom", "rand_core"]
 heapless = ["aead/heapless"]
 rand_core = ["aead/rand_core"]

--- a/crypto_secretbox/tests/xsalsa20poly1305.rs
+++ b/crypto_secretbox/tests/xsalsa20poly1305.rs
@@ -2,6 +2,8 @@
 //!
 //! Adapted from NaCl's `tests/secretbox.c` and `tests/secretbox.out`
 
+#![cfg(feature = "salsa20")]
+
 use crypto_secretbox::{
     aead::{generic_array::GenericArray, Aead, KeyInit},
     XSalsa20Poly1305,


### PR DESCRIPTION
The intent is to allow using it with `chacha20` exclusively if desired.