### PR TITLE
crypto_secretbox: add `chacha20` feature

### DIFF
--- a/.github/workflows/crypto_secretbox.yml
+++ b/.github/workflows/crypto_secretbox.yml
@@ -35,7 +35,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features chacha20
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features heapless
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features salsa20
 
   test:
     runs-on: ubuntu-latest
@@ -49,8 +51,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      - run: cargo test --release --no-default-features
+      - run: cargo test --release
       - run: cargo test --release --features std
       - run: cargo test --release --features std,heapless
+      - run: cargo test --release --all-features
 
   cross:
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ name = "crypto_secretbox"
 version = "0.0.0"
 dependencies = [
  "aead",
+ "chacha20",
  "cipher",
  "poly1305",
  "salsa20",

--- a/crypto_secretbox/Cargo.toml
+++ b/crypto_secretbox/Cargo.toml
@@ -23,6 +23,7 @@ subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies
+chacha20 = { version = "0.9", optional = true, features = ["zeroize"] }
 salsa20 = { version = "0.10", optional = true, features = ["zeroize"] }
 
 [features]

--- a/crypto_secretbox/README.md
+++ b/crypto_secretbox/README.md
@@ -7,14 +7,14 @@
 [![Project Chat][chat-image]][chat-link]
 [![Build Status][build-image]][build-link]
 
-**XSalsa20Poly1305** (a.k.a. NaCl [`crypto_secretbox`][1]) is an
-[authenticated encryption][2] cipher amenable to fast, constant-time
-implementations in software, based on the [Salsa20][3] stream cipher
-(with [XSalsa20][4] 192-bit nonce extension) and the [Poly1305][5] universal
-hash function, which acts as a message authentication code.
+[`crypto_secretbox`][1] is an [authenticated symmetric encryption][2] cipher
+amenable to fast, constant-time implementations in software, combining either the
+[Salsa20][3] stream cipher (with [XSalsa20][4] 192-bit nonce extension) or
+[ChaCha20][5] stream cipher with the [Poly1305][6] universal hash function,
+which acts as a message authentication code.
 
-This algorithm has largely been replaced by the newer [ChaCha20Poly1305][6]
-(and the associated [XChaCha20Poly1305][7]) AEAD ciphers ([RFC 8439][8]),
+This algorithm has largely been replaced by the newer [ChaCha20Poly1305][7]
+(and the associated [XChaCha20Poly1305][8]) AEAD ciphers ([RFC 8439][9]),
 but is useful for interoperability with legacy NaCl-based protocols.
 
 [Documentation][docs-link]
@@ -61,7 +61,8 @@ dual licensed as above, without any additional terms or conditions.
 [2]: https://en.wikipedia.org/wiki/Authenticated_encryption
 [3]: https://github.com/RustCrypto/stream-ciphers/tree/master/salsa20
 [4]: https://cr.yp.to/snuffle/xsalsa-20081128.pdf
-[5]: https://github.com/RustCrypto/universal-hashes/tree/master/poly1305
-[6]: https://github.com/RustCrypto/AEADs/tree/master/chacha20poly1305
-[7]: https://docs.rs/chacha20poly1305/latest/chacha20poly1305/struct.XChaCha20Poly1305.html
-[8]: https://tools.ietf.org/html/rfc8439
+[5]: https://cr.yp.to/chacha.html
+[6]: https://github.com/RustCrypto/universal-hashes/tree/master/poly1305
+[7]: https://github.com/RustCrypto/AEADs/tree/master/chacha20poly1305
+[8]: https://docs.rs/chacha20poly1305/latest/chacha20poly1305/struct.XChaCha20Poly1305.html
+[9]: https://tools.ietf.org/html/rfc8439


### PR DESCRIPTION
Adds `chacha20` feature providing a `XChaCha20Poly1305` type alias.

Note that this construction of "XChaCha20Poly1305" is different from the one implemented by the `chacha20poly1305` crate, which implements constructions based on the IETF variant of ChaCha20Poly1305.

The flavor of `XChaCha20Poly1305` in this crate is based on pre-IETF constructions and is only supported by libsodium.

This is an unfortunate state of affairs to have two incompatible constructions with the same name. One of the original goals of `draft-irtf-cfrg-xchacha` was to ensure that "XChaCha20" was always based on the IETF variant of ChaCha20.

The `AEAD_XChaCha20_Poly1305` construction that I-D defines is only compatible with the version implemented by the `chacha20poly1305` crate, and is *INCOMPATIBLE* with the construction provided by this crate, which lacks features like AAD and is therefore not a full AEAD mode.

Comments to this effect have been left on the `XChaCha20Poly1305` type definition in this crate.