### PR TITLE
crypto_secretbox: use `Salsa20` and `ChaCha20Legacy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,7 @@ dependencies = [
  "aead",
  "chacha20",
  "cipher",
+ "generic-array",
  "poly1305",
  "salsa20",
  "subtle",
@@ -323,6 +324,7 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]

--- a/crypto_secretbox/Cargo.toml
+++ b/crypto_secretbox/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.60"
 [dependencies]
 aead = { version = "0.5", default-features = false }
 cipher = { version = "0.4", default-features = false }
+generic-array = { version = "0.14.6", default-features = false, features = ["zeroize"] }
 poly1305 = "0.8"
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }


### PR DESCRIPTION
Previously this was using the IETF variant of ChaCha20, but for compatibility with e.g. libsodium we need to use the original DJB variant.

This also changes to using the `Salsa20` (as opposed to `XSalsa20`) type and using the `Kdf` trait to impl both `XSalsa20` and `XChaCha20`, since the `chacha20` version of `XChaCha20` is built on the IETF variant of `ChaCha20` (so as to be compatible with draft-irtf-cfrg-xchacha).