### PR TITLE
crypto_secretbox v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_secretbox"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aead",
  "chacha20",

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.60"
 
 [dependencies]
 aead = { version = "0.5.2", default-features = false }
-crypto_secretbox = { version = "0.1", default-features = false, path = "../crypto_secretbox" }
+crypto_secretbox = { version = "0.1.1", default-features = false, path = "../crypto_secretbox" }
 curve25519-dalek = { version = "=4.0.0-rc.2", default-features = false, features = ["zeroize"] }
 zeroize = { version = "1", default-features = false }
 

--- a/crypto_secretbox/CHANGELOG.md
+++ b/crypto_secretbox/CHANGELOG.md
@@ -4,5 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2023-05-15)
+### Added
+- Re-export `cipher` ([#113])
+
+[#113]: https://github.com/RustCrypto/nacl-compat/pull/113
+
 ## 0.1.0 (2023-05-15)
 - Initial release

--- a/crypto_secretbox/Cargo.toml
+++ b/crypto_secretbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_secretbox"
-version = "0.1.0"
+version = "0.1.1"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption cipher as well as the libsodium variant of


### PR DESCRIPTION
### Added
- Re-export `cipher` ([#113])

[#113]: https://github.com/RustCrypto/nacl-compat/pull/113