### PR TITLE
crypto_box: remove `rand_core` reexport

### DIFF
--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -173,9 +173,6 @@ pub use crate::{public_key::PublicKey, secret_key::SecretKey};
 pub use aead;
 pub use crypto_secretbox::Nonce;
 
-#[cfg(feature = "rand_core")]
-pub use aead::rand_core;
-
 use aead::{
     consts::{U0, U16, U24, U32, U8},
     generic_array::GenericArray,


### PR DESCRIPTION
`rand_core` is available as `crypto_box::aead::rand_core`, and `OsRng` is available via `crypto_box::aead::OsRng`, as is used in the crate's documentation.