### PR TITLE
crypto_box: make `seal` and `unseal` inherent methods

### DIFF
--- a/crypto_box/src/public_key.rs
+++ b/crypto_box/src/public_key.rs
@@ -2,6 +2,13 @@ use crate::{SecretKey, KEY_SIZE};
 use core::cmp::Ordering;
 use curve25519_dalek::MontgomeryPoint;
 
+#[cfg(feature = "seal")]
+use {
+    crate::{get_seal_nonce, SalsaBox, TAG_SIZE},
+    aead::{rand_core::CryptoRngCore, Aead},
+    alloc::vec::Vec,
+};
+
 #[cfg(feature = "serde")]
 use serdect::serde::{de, ser, Deserialize, Serialize};
 
@@ -31,6 +38,30 @@ impl PublicKey {
     /// Serialize this public key as bytes.
     pub fn to_bytes(&self) -> [u8; KEY_SIZE] {
         self.0.to_bytes()
+    }
+
+    /// Implementation of `crypto_box_seal` function from [libsodium "sealed boxes"].
+    ///
+    /// Sealed boxes are designed to anonymously send messages to a recipient given their public key.
+    ///
+    /// [libsodium "sealed boxes"]: https://doc.libsodium.org/public-key_cryptography/sealed_boxes
+    #[cfg(feature = "seal")]
+    pub fn seal(
+        &self,
+        csprng: &mut impl CryptoRngCore,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, aead::Error> {
+        let mut out = Vec::with_capacity(KEY_SIZE + TAG_SIZE + plaintext.len());
+        let ephemeral_sk = SecretKey::generate(csprng);
+        let ephemeral_pk = ephemeral_sk.public_key();
+        out.extend_from_slice(ephemeral_pk.as_bytes());
+
+        let nonce = get_seal_nonce(&ephemeral_pk, self);
+        let salsabox = SalsaBox::new(self, &ephemeral_sk);
+        let encrypted = salsabox.encrypt(&nonce, plaintext)?;
+        out.extend_from_slice(&encrypted);
+
+        Ok(out)
     }
 }
 

--- a/crypto_box/tests/lib.rs
+++ b/crypto_box/tests/lib.rs
@@ -180,15 +180,10 @@ fn seal() {
         0x54, 0x58, 0xb8, 0xa6, 0xbd, 0x71, 0x2d, 0xd8, 0x36, 0x55, 0x34, 0xc5, 0x67, 0xec,
     ];
 
-    use crypto_box::{seal, seal_open};
+    let pk = PublicKey::from(SEAL_PUBLIC_KEY);
+    let encrypted = pk.seal(&mut OsRng, SEAL_PLAINTEXT).unwrap();
 
-    let encrypted = seal(&mut OsRng, &SEAL_PUBLIC_KEY.into(), SEAL_PLAINTEXT).unwrap();
-    assert_eq!(
-        SEAL_PLAINTEXT,
-        seal_open(&SEAL_SECRET_KEY.into(), &encrypted).unwrap()
-    );
-    assert_eq!(
-        SEAL_PLAINTEXT,
-        seal_open(&SEAL_SECRET_KEY.into(), SEAL_CIPHERTEXT).unwrap()
-    );
+    let sk = SecretKey::from(SEAL_SECRET_KEY);
+    assert_eq!(SEAL_PLAINTEXT, sk.unseal(&encrypted).unwrap());
+    assert_eq!(SEAL_PLAINTEXT, sk.unseal(SEAL_CIPHERTEXT).unwrap());
 }


### PR DESCRIPTION
- Moves `seal` to `PublicKey::seal`
- Moves `seal_open` to `SecretKey::unseal`

This should make these slightly more convenient to use by reducing the number of imports required.