### PR TITLE
crypto_box v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.9.0-rc.1"
+version = "0.9.0"
 dependencies = [
  "aead",
  "bincode",

--- a/crypto_box/CHANGELOG.md
+++ b/crypto_box/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.0-rc.0 (2023-05-16)
+## 0.9.0 (2023-07-22)
 
 COMPATIBILITY NOTE: previous versions of this crate provided a `ChaChaBox`
 construction which is incompatible with the one in libsodium. This release
@@ -20,11 +20,12 @@ inconvenience.
 
 ### Changed
 - Use `crypto_secretbox` crate for symmetric cryptography ([#82], [#109])
-- Replaced `x25519-dalek` with `curve25519-dalek` v4.0.0-rc; MSRV 1.60 ([#88])
+- Replaced `x25519-dalek` with `curve25519-dalek` v4; MSRV 1.60 ([#88], [#130])
 - Use `MontgomeryPoint` as `PublicKey`'s inner type ([#91])
 - Make `seal` and `unseal` inherent methods ([#118])
   - `seal` => `PublicKey::seal`
   - `seal_open` => `SecretKey::unseal`
+- Consistent constructors for `PublicKey`/`SecretKey` ([#119])
 
 ### Removed
 - `rand_core` reexport ([#116])
@@ -38,6 +39,8 @@ inconvenience.
 [#113]: https://github.com/RustCrypto/nacl-compat/pull/113
 [#116]: https://github.com/RustCrypto/nacl-compat/pull/116
 [#118]: https://github.com/RustCrypto/nacl-compat/pull/118
+[#119]: https://github.com/RustCrypto/nacl-compat/pull/119
+[#130]: https://github.com/RustCrypto/nacl-compat/pull/130
 
 ## 0.8.2 (2022-10-29)
 ### Added

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_box"
-version = "0.9.0-rc.1"
+version = "0.9.0"
 description = """
 Pure Rust implementation of NaCl's crypto_box public-key authenticated
 encryption primitive which combines the X25519 Elliptic Curve Diffie-Hellman

--- a/crypto_box/LICENSE-MIT
+++ b/crypto_box/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020 The RustCrypto Project Developers
+Copyright (c) 2020-2023 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
COMPATIBILITY NOTE: previous versions of this crate provided a `ChaChaBox` construction which is incompatible with the one in libsodium. This release makes breaking changes to that construction which provide compatibility with the libsodium implementation. No backwards compatibility is provided for the construction in previous releases of this crate. We apologize for the inconvenience.

### Added
- `SEALBYTES` constant ([#81])
- `serde` impl for `SecretKey` ([#101])
- Generic implementation of `CryptoBox` ([#113])

### Changed
- Use `crypto_secretbox` crate for symmetric cryptography ([#82], [#109])
- Replaced `x25519-dalek` with `curve25519-dalek` v4; MSRV 1.60 ([#88], [#130])
- Use `MontgomeryPoint` as `PublicKey`'s inner type ([#91])
- Make `seal` and `unseal` inherent methods ([#118])
  - `seal` => `PublicKey::seal`
  - `seal_open` => `SecretKey::unseal`
- Consistent constructors for `PublicKey`/`SecretKey` ([#119])

### Removed
- `rand_core` reexport ([#116])

[#81]: https://github.com/RustCrypto/nacl-compat/pull/81
[#82]: https://github.com/RustCrypto/nacl-compat/pull/82
[#88]: https://github.com/RustCrypto/nacl-compat/pull/88
[#91]: https://github.com/RustCrypto/nacl-compat/pull/91
[#101]: https://github.com/RustCrypto/nacl-compat/pull/101
[#109]: https://github.com/RustCrypto/nacl-compat/pull/109
[#113]: https://github.com/RustCrypto/nacl-compat/pull/113
[#116]: https://github.com/RustCrypto/nacl-compat/pull/116
[#118]: https://github.com/RustCrypto/nacl-compat/pull/118
[#119]: https://github.com/RustCrypto/nacl-compat/pull/119
[#130]: https://github.com/RustCrypto/nacl-compat/pull/130