### PR TITLE
crypto_kx: use `CryptoRngCore`; cleanup deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,11 +204,10 @@ dependencies = [
 
 [[package]]
 name = "crypto_kx"
-version = "0.2.0-pre.0"
+version = "0.2.0"
 dependencies = [
  "blake2",
  "curve25519-dalek",
- "getrandom",
  "rand_core",
  "serdect",
 ]

--- a/crypto_kx/Cargo.toml
+++ b/crypto_kx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_kx"
-version = "0.2.0-pre.0"
+version = "0.2.0"
 description = "Pure Rust implementation of libsodium's crypto_kx using BLAKE2"
 authors = ["C4DT", "RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -16,20 +16,17 @@ rust-version = "1.60"
 [dependencies]
 blake2 = { version = "0.10", default-features = false }
 curve25519-dalek = { version = "4", default-features = false, features = ["zeroize"] }
-rand_core = "0.6"
+rand_core = "0.6.4"
 
 # optional dependencies
 serdect = { version = "0.2", optional = true, default-features = false }
 
-[target.'cfg(target_family = "wasm")'.dependencies]
-getrandom = { version = "0.2", default-features = false, features = ["js"] }
-
 [dev-dependencies]
-rand_core = { version = "0.6", features = ["std"] }
+rand_core = { version = "0.6", features = ["getrandom"] }
 
 [features]
 serde = ["serdect"]
-std = ["blake2/std", "rand_core/std"]
+getrandom = ["rand_core/getrandom"]
 
 [package.metadata.docs.rs]
 features = ["serde", "seal"]

--- a/crypto_kx/src/keypair.rs
+++ b/crypto_kx/src/keypair.rs
@@ -1,5 +1,5 @@
 use blake2::{digest::generic_array::sequence::Split, Blake2b512, Digest};
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 
 use crate::{ClientSessionKeys, PublicKey, SecretKey, ServerSessionKeys, SessionKey};
 
@@ -11,7 +11,7 @@ pub struct Keypair {
 
 impl Keypair {
     /// Generate a new random [`Keypair`].
-    pub fn generate(csprng: impl RngCore + CryptoRng) -> Self {
+    pub fn generate(csprng: &mut impl CryptoRngCore) -> Self {
         SecretKey::generate(csprng).into()
     }
 

--- a/crypto_kx/src/keys/secret.rs
+++ b/crypto_kx/src/keys/secret.rs
@@ -2,7 +2,7 @@
 
 use crate::{errors::InvalidLength, PublicKey};
 use curve25519_dalek::MontgomeryPoint;
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 
 #[cfg(feature = "serde")]
 use serdect::serde::{de, ser, Deserialize, Serialize};
@@ -16,7 +16,7 @@ impl SecretKey {
     pub const BYTES: usize = 32;
 
     /// Generate a new random [`SecretKey`].
-    pub fn generate(mut csprng: impl RngCore + CryptoRng) -> Self {
+    pub fn generate(csprng: &mut impl CryptoRngCore) -> Self {
         let mut bytes = [0u8; Self::BYTES];
         csprng.fill_bytes(&mut bytes);
         bytes.into()

--- a/crypto_kx/src/lib.rs
+++ b/crypto_kx/src/lib.rs
@@ -13,8 +13,8 @@
 //! use rand_core::OsRng;
 //!
 //! // Each generates a key on their machine.
-//! let alice = Keypair::generate(OsRng);
-//! let betty = Keypair::generate(OsRng);
+//! let alice = Keypair::generate(&mut OsRng);
+//! let betty = Keypair::generate(&mut OsRng);
 //!
 //! // Then Alice decides to send a message to Betty, so she computes the shared keys.
 //! let alice_keys = alice.session_keys_to(betty.public());

--- a/crypto_kx/tests/lib.rs
+++ b/crypto_kx/tests/lib.rs
@@ -3,8 +3,8 @@ use rand_core::OsRng;
 
 #[test]
 fn client_keys_is_reverse_from_server_keys() {
-    let client = Keypair::generate(OsRng);
-    let server = Keypair::generate(OsRng);
+    let client = Keypair::generate(&mut OsRng);
+    let server = Keypair::generate(&mut OsRng);
 
     let client_keys = client.session_keys_to(server.public());
     let server_keys = server.session_keys_from(client.public());


### PR DESCRIPTION
Uses the `CryptoRngCore` trait alias as introduced in `rand_core` v0.6.4.

Also removes extraneous dependencies.