### PR TITLE
crypto_secretstream v0.2.0

### DIFF
--- a/crypto_secretstream/CHANGELOG.md
+++ b/crypto_secretstream/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2023-07-22)
+### Added
+- Constant corresponding to `crypto_secretstream_xchacha20poly1305_ABYTES` ([#81])
+
+### Changed
+- MSRV 1.60 ([#88])
+
+[#81]: https://github.com/RustCrypto/nacl-compat/pull/81
+[#88]: https://github.com/RustCrypto/nacl-compat/pull/88
+
 ## 0.1.1 (2022-12-01)
 ### Fixed
 - WASM problem with 32-bit usize and `copy_with_slice` expecting 8-bytes ([#76])

--- a/crypto_secretstream/Cargo.toml
+++ b/crypto_secretstream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_secretstream"
-version = "0.2.0-pre"
+version = "0.2.0"
 description = """
 Pure Rust implementation of libsodium's crypto_secretstream secret-key using
 ChaCha20 and Poly1305


### PR DESCRIPTION
### Added
- Constant corresponding to `crypto_secretstream_xchacha20poly1305_ABYTES` ([#81])

### Changed
- MSRV 1.60 ([#88])

[#81]: https://github.com/RustCrypto/nacl-compat/pull/81
[#88]: https://github.com/RustCrypto/nacl-compat/pull/88