### PR TITLE
crypto_box: fix `Scalar` conversion to `SecretKey`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
  "rmp-serde",
  "salsa20",
  "serdect",
+ "subtle",
  "zeroize",
 ]
 

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -21,6 +21,7 @@ rust-version = "1.60"
 aead = { version = "0.5.2", default-features = false }
 crypto_secretbox = { version = "0.1.1", default-features = false, path = "../crypto_secretbox" }
 curve25519-dalek = { version = "4", default-features = false, features = ["zeroize"] }
+subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies

--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -241,7 +241,7 @@ impl<C> CryptoBox<C> {
     where
         C: Kdf,
     {
-        let shared_secret = Zeroizing::new(public_key.0.mul_clamped(secret_key.0));
+        let shared_secret = Zeroizing::new(secret_key.scalar * public_key.0);
 
         // Use HChaCha20 to create a uniformly random key from the shared secret
         let key = Zeroizing::new(C::kdf(

--- a/crypto_box/src/secret_key.rs
+++ b/crypto_box/src/secret_key.rs
@@ -78,6 +78,9 @@ impl SecretKey {
     /// value may not reflect the original scalar prior to clamping. We suggest
     /// you don't call this method when using `From<Scalar>` unless you know
     /// what you're doing.
+    ///
+    /// Calling [`SecretKey::to_scalar`] can be used to safely round-trip the
+    /// scalar value in such cases.
     pub fn to_bytes(&self) -> [u8; KEY_SIZE] {
         self.bytes
     }

--- a/crypto_box/src/secret_key.rs
+++ b/crypto_box/src/secret_key.rs
@@ -65,6 +65,19 @@ impl SecretKey {
     ///
     /// The serialized bytes are secret key material. Please treat them with
     /// the care they deserve!
+    ///
+    /// # `Scalar` conversion notes
+    ///
+    /// If you are using the `From<Scalar>` impl on [`SecretKey`] (as opposed
+    /// to using [`SecretKey::from_bytes`] or one of the other methods that
+    /// decodes a secret key from bytes), this method will return the same
+    /// value as `Scalar::to_bytes`, which may reflect "clamping" if it was
+    /// applied to the original `Scalar`.
+    ///
+    /// In such cases, it may be undesirable to call this method, since such a
+    /// value may not reflect the original scalar prior to clamping. We suggest
+    /// you don't call this method when using `From<Scalar>` unless you know
+    /// what you're doing.
     pub fn to_bytes(&self) -> [u8; KEY_SIZE] {
         self.bytes
     }

--- a/crypto_box/src/secret_key.rs
+++ b/crypto_box/src/secret_key.rs
@@ -3,7 +3,11 @@ use core::{
     array::TryFromSliceError,
     fmt::{self, Debug},
 };
-use curve25519_dalek::{MontgomeryPoint, Scalar};
+use curve25519_dalek::{
+    scalar::{clamp_integer, Scalar},
+    MontgomeryPoint,
+};
+use subtle::ConstantTimeEq;
 use zeroize::Zeroize;
 
 #[cfg(feature = "rand_core")]
@@ -21,13 +25,17 @@ use serdect::serde::{de, ser, Deserialize, Serialize};
 
 /// A `crypto_box` secret key.
 #[derive(Clone)]
-pub struct SecretKey(pub(crate) [u8; KEY_SIZE]);
+pub struct SecretKey {
+    pub(crate) bytes: [u8; KEY_SIZE],
+    pub(crate) scalar: Scalar,
+}
 
 impl SecretKey {
     /// Initialize [`SecretKey`] from a byte array.
     #[inline]
     pub fn from_bytes(bytes: [u8; KEY_SIZE]) -> Self {
-        SecretKey(bytes)
+        let scalar = Scalar::from_bytes_mod_order(clamp_integer(bytes));
+        Self { bytes, scalar }
     }
 
     /// Initialize [`SecretKey`] from a byte slice.
@@ -48,7 +56,7 @@ impl SecretKey {
 
     /// Get the [`PublicKey`] which corresponds to this [`SecretKey`]
     pub fn public_key(&self) -> PublicKey {
-        PublicKey(MontgomeryPoint::mul_base_clamped(self.0))
+        PublicKey(MontgomeryPoint::mul_base(&self.scalar))
     }
 
     /// Serialize [`SecretKey`] to bytes.
@@ -58,7 +66,16 @@ impl SecretKey {
     /// The serialized bytes are secret key material. Please treat them with
     /// the care they deserve!
     pub fn to_bytes(&self) -> [u8; KEY_SIZE] {
-        self.0
+        self.bytes
+    }
+
+    /// Obtain the inner [`Scalar`] value of this [`SecretKey`].
+    ///
+    /// # ⚠️Warning
+    ///
+    /// This value is key material. Please treat it with the care it deserves!
+    pub fn to_scalar(&self) -> Scalar {
+        self.scalar
     }
 
     /// Implementation of `crypto_box_seal_open` function from [libsodium "sealed boxes"].
@@ -80,15 +97,36 @@ impl SecretKey {
     }
 }
 
+impl Debug for SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SecretKey").finish_non_exhaustive()
+    }
+}
+
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        self.scalar.zeroize();
+    }
+}
+
+impl Eq for SecretKey {}
+
 impl From<Scalar> for SecretKey {
-    fn from(value: Scalar) -> Self {
-        SecretKey(value.to_bytes())
+    fn from(scalar: Scalar) -> Self {
+        let bytes = scalar.to_bytes();
+        SecretKey { bytes, scalar }
     }
 }
 
 impl From<[u8; KEY_SIZE]> for SecretKey {
     fn from(bytes: [u8; KEY_SIZE]) -> SecretKey {
         Self::from_bytes(bytes)
+    }
+}
+
+impl PartialEq for SecretKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.scalar.ct_eq(&other.scalar).into()
     }
 }
 
@@ -100,25 +138,13 @@ impl TryFrom<&[u8]> for SecretKey {
     }
 }
 
-impl Debug for SecretKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SecretKey").finish_non_exhaustive()
-    }
-}
-
-impl Drop for SecretKey {
-    fn drop(&mut self) {
-        self.0.zeroize();
-    }
-}
-
 #[cfg(feature = "serde")]
 impl Serialize for SecretKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
     {
-        serdect::array::serialize_hex_upper_or_bin(&self.0, serializer)
+        serdect::array::serialize_hex_upper_or_bin(&self.to_bytes(), serializer)
     }
 }
 

--- a/crypto_box/tests/lib.rs
+++ b/crypto_box/tests/lib.rs
@@ -13,6 +13,7 @@ use crypto_box::{
     aead::{generic_array::GenericArray, Aead, AeadInPlace, OsRng},
     PublicKey, SecretKey,
 };
+use curve25519_dalek::EdwardsPoint;
 use hex_literal::hex;
 
 // Alice's keypair
@@ -55,6 +56,16 @@ fn secret_and_public_keys() {
     dbg!(&secret_key);
 
     assert_eq!(secret_key.public_key().as_bytes(), &ALICE_PUBLIC_KEY);
+}
+
+#[test]
+fn edwards_to_montgomery() {
+    let secret_key = SecretKey::from(ALICE_SECRET_KEY);
+    let scalar = secret_key.to_scalar();
+    let point = EdwardsPoint::mul_base(&scalar);
+    let public_key = PublicKey::from(point.to_montgomery());
+    assert_eq!(secret_key.public_key(), public_key);
+    assert_eq!(secret_key, SecretKey::from(scalar));
 }
 
 macro_rules! impl_tests {


### PR DESCRIPTION
Avoids round tripping `Scalar` to/from bytes when leveraging the `From<Scalar>` impl for `SecretKey`.