### PR TITLE
crypto_box v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aead",
  "bincode",

--- a/crypto_box/CHANGELOG.md
+++ b/crypto_box/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.1 (2023-08-17)
+### Fixed
+- `Scalar` conversion to `SecretKey` ([#137])
+
+[#137]: https://github.com/RustCrypto/nacl-compat/pull/137
+
 ## 0.9.0 (2023-07-22)
 
 COMPATIBILITY NOTE: previous versions of this crate provided a `ChaChaBox`

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_box"
-version = "0.9.0"
+version = "0.9.1"
 description = """
 Pure Rust implementation of NaCl's crypto_box public-key authenticated
 encryption primitive which combines the X25519 Elliptic Curve Diffie-Hellman


### PR DESCRIPTION
### Fixed
- `Scalar` conversion to `SecretKey` ([#137])

[#137]: https://github.com/RustCrypto/nacl-compat/pull/137