### PR TITLE
Avoid `Clone` bound for the type parameter of `CryptoBox`.

### DIFF
--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -229,9 +229,17 @@ pub type SalsaBox = CryptoBox<Salsa20>;
 ///
 /// [X25519]: https://cr.yp.to/ecdh.html
 /// [crypto_secretbox]: https://github.com/RustCrypto/nacl-compat/tree/master/crypto_secretbox
-#[derive(Clone)]
 pub struct CryptoBox<C> {
     secretbox: SecretBox<C>,
+}
+
+// Handwritten instead of derived to avoid `C: Clone` bound
+impl<C> Clone for CryptoBox<C> {
+    fn clone(&self) -> Self {
+        Self {
+            secretbox: self.secretbox.clone(),
+        }
+    }
 }
 
 impl<C> CryptoBox<C> {


### PR DESCRIPTION
See https://github.com/RustCrypto/stream-ciphers/pull/331