### PR TITLE
feat(crypto_box): add consts like SecretBox

### DIFF
--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -233,6 +233,17 @@ pub struct CryptoBox<C> {
     secretbox: SecretBox<C>,
 }
 
+impl<C> CryptoBox<C> {
+    /// Size of an XSalsa20Poly1305 key in bytes
+    pub const KEY_SIZE: usize = SecretBox::<C>::KEY_SIZE;
+
+    /// Size of an XSalsa20Poly1305 nonce in bytes
+    pub const NONCE_SIZE: usize = SecretBox::<C>::NONCE_SIZE;
+
+    /// Size of a Poly1305 tag in bytes
+    pub const TAG_SIZE: usize = SecretBox::<C>::TAG_SIZE;
+}
+
 // Handwritten instead of derived to avoid `C: Clone` bound
 impl<C> Clone for CryptoBox<C> {
     fn clone(&self) -> Self {


### PR DESCRIPTION
In `crypto_secretbox`, there are pub consts we can use.
```
impl<C> SecretBox<C> {
    /// Size of an XSalsa20Poly1305 key in bytes
    pub const KEY_SIZE: usize = 32;

    /// Size of an XSalsa20Poly1305 nonce in bytes
    pub const NONCE_SIZE: usize = 24;

    /// Size of a Poly1305 tag in bytes
    pub const TAG_SIZE: usize = 16;
}
```
Maybe it's better to bring these consts to `crypto_box` too? So we don't have to use magic numbers without import the `crypto_secretbox`.