### PR TITLE
Update Cargo.toml

### DIFF
--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.60"
 [dependencies]
 aead = { version = "0.5.2", default-features = false }
 crypto_secretbox = { version = "0.1.1", default-features = false, path = "../crypto_secretbox" }
-curve25519-dalek = { version = "4", default-features = false, features = ["zeroize"] }
+curve25519-dalek = { version = "4.1.3", default-features = false, features = ["zeroize"] }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 


### PR DESCRIPTION
Bumps the dependency to at least 4.1.3 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0344.html) 

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)