### PR TITLE
Fix diffie hellman computation

### DIFF
--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -260,7 +260,7 @@ impl<C> CryptoBox<C> {
     where
         C: Kdf,
     {
-        let shared_secret = Zeroizing::new(secret_key.scalar * public_key.0);
+        let shared_secret = Zeroizing::new(public_key.0.mul_clamped(secret_key.bytes));
 
         // Use HChaCha20 to create a uniformly random key from the shared secret
         let key = Zeroizing::new(C::kdf(

--- a/crypto_box/tests/lib.rs
+++ b/crypto_box/tests/lib.rs
@@ -152,6 +152,7 @@ mod xsalsa20poly1305 {
 #[cfg(feature = "chacha20")]
 mod xchacha20poly1305 {
     use super::*;
+    use aead::Nonce;
     use crypto_box::ChaChaBox;
     const CIPHERTEXT: &[u8] = &hex!(
         "0cd5ed093de698c8e410d0d451df2f5283057376b947b9b7392b956e5d675f309218acce8cf85f6c"
@@ -161,6 +162,24 @@ mod xchacha20poly1305 {
     );
 
     impl_tests!(ChaChaBox, PLAINTEXT, CIPHERTEXT);
+
+    /// Implement test against shared secret being all zero
+    #[test]
+    fn test_public_key_on_twist() {
+        let alice_private_key: [u8; 32] =
+            hex!("78d37f87f45e76aae3b61e0f0b69db96d117f8b5fd8edc73785b64918d2c9f47");
+        let bob_public_key: [u8; 32] =
+            hex!("9ec59406d5f9fde97a5c49acb935023ae40fae1499c05d3277cfb9100487e5b8");
+        let nonce = hex!("979f38f433649e8aa1ad5a0334223f7c7dabc80231e8233a");
+        let plaintext: &[u8] = &[];
+        let ciphertext_expected = hex!("171e01986d83c429a2746212464d6782");
+
+        let ciphertext_computed = ChaChaBox::new(&bob_public_key.into(), &alice_private_key.into())
+            .encrypt(Nonce::<ChaChaBox>::from_slice(&nonce), plaintext)
+            .expect("Encryption should work");
+
+        assert_eq!(ciphertext_computed, ciphertext_expected)
+    }
 }
 
 #[cfg(feature = "seal")]

--- a/test-vector-gen/src/crypto_box.rs
+++ b/test-vector-gen/src/crypto_box.rs
@@ -32,6 +32,7 @@ const BOXZEROBYTES: usize = 16;
 
 pub fn generate() {
     generate_xchacha20poly1305();
+    generate_xchacha20poly1305_public_key_on_twist();
 }
 
 fn generate_xchacha20poly1305() {
@@ -50,6 +51,32 @@ fn generate_xchacha20poly1305() {
     assert_eq!(ret, 0);
     println!(
         "CHACHA20POLY1305_BOX_CIPHERTEXT: &[u8] = &hex!(\"{}\");",
+        hex::encode(ct)
+    );
+}
+
+fn generate_xchacha20poly1305_public_key_on_twist() {
+    let alice_private_key: [u8; 32] =
+        hex!("78d37f87f45e76aae3b61e0f0b69db96d117f8b5fd8edc73785b64918d2c9f47");
+    let bob_public_key: [u8; 32] =
+        hex!("9ec59406d5f9fde97a5c49acb935023ae40fae1499c05d3277cfb9100487e5b8");
+    let nonce = hex!("979f38f433649e8aa1ad5a0334223f7c7dabc80231e8233a");
+    const PLAINTEXT: [u8; 0] = [];
+    let mut ct = [42u8; BOXZEROBYTES + PLAINTEXT.len()];
+
+    let ret = unsafe {
+        libsodium_sys::crypto_box_curve25519xchacha20poly1305_easy(
+            ct.as_mut_ptr(),
+            PLAINTEXT.as_ptr(),
+            PLAINTEXT.len() as u64,
+            nonce.as_ptr(),
+            bob_public_key.as_ptr(),
+            alice_private_key.as_ptr(),
+        )
+    };
+    assert_eq!(ret, 0);
+    println!(
+        "CHACHA20POLY1305_BOX_CIPHERTEXT_PUBLIC_KEY_ON_TWIST: &[u8] = &hex!(\"{}\");",
         hex::encode(ct)
     );
 }


### PR DESCRIPTION
`crypto_box` currently uses the `*` operator directly to multiply the `secret_key.scalar` and the `public_key.0`.
This results in a minor incompatibility with libsodium, especially for specially drafted public keys.

This MR adds
1.  a test for one such special case, i.e., the public key being on the twist of a curve. Along with this comes the function of generating the ciphertext with libsodium, see `test-vector-gen/src/crypto_box.rs`. This test is taken from [bleichenbacher-daniel/Rooterberg](https://github.com/bleichenbacher-daniel/Rooterberg/blob/979eadc6b2e3868a7fd2afffec14e977adf19f30/test_vectors/nacl_crypto_box/nacl_crypto_box_curve25519_xchacha20_poly1305.json#L2079-L2093).
2. a fix for the Diffie-Hellman computation that essentially copies the code for multiplication from [x25519_dalek](https://github.com/dalek-cryptography/curve25519-dalek/blob/fbf1fb5339b22eaf9925e520c90f1821f79ef5db/x25519-dalek/src/x25519.rs#L202).

To reproduce the issue, clone this repository, and run the tests.
- Without the fix (second commit), the tests fail.
- With the fix, the tests succeed.
