### PR TITLE
crypto_box: add `SecretKey::as_bytes` method

### DIFF
--- a/crypto_box/src/secret_key.rs
+++ b/crypto_box/src/secret_key.rs
@@ -59,6 +59,32 @@ impl SecretKey {
         PublicKey(MontgomeryPoint::mul_base(&self.scalar))
     }
 
+    /// Borrows [`SecretKey`] as bytes.
+    ///
+    /// # ⚠️Warning
+    ///
+    /// The bytes are secret key material. Please treat them with
+    /// the care they deserve!
+    ///
+    /// # `Scalar` conversion notes
+    ///
+    /// If you are using the `From<Scalar>` impl on [`SecretKey`] (as opposed
+    /// to using [`SecretKey::from_bytes`] or one of the other methods that
+    /// decodes a secret key from bytes), this method will return the same
+    /// value as `Scalar::to_bytes`, which may reflect "clamping" if it was
+    /// applied to the original `Scalar`.
+    ///
+    /// In such cases, it may be undesirable to call this method, since such a
+    /// value may not reflect the original scalar prior to clamping. We suggest
+    /// you don't call this method when using `From<Scalar>` unless you know
+    /// what you're doing.
+    ///
+    /// Calling [`SecretKey::to_scalar`] can be used to safely round-trip the
+    /// scalar value in such cases.
+    pub fn as_bytes(&self) -> &[u8; KEY_SIZE] {
+        &self.bytes
+    }
+
     /// Serialize [`SecretKey`] to bytes.
     ///
     /// # ⚠️Warning


### PR DESCRIPTION
`crypto_box::PublicKey` has this method and would be useful for the secret key as well.