### PR TITLE
.cargo/audit.toml: fix audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,2 +1,2 @@
 [advisories]
-ignore = ["RUSTSEC-2021-0137"]
+ignore = ["RUSTSEC-2024-0436"]


### PR DESCRIPTION
We don't care `paste` is unmaintained