### PR TITLE
Bump all version numbers to prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.9.1"
+version = "0.10.0-pre"
 dependencies = [
  "aead",
  "bincode",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_kx"
-version = "0.2.1"
+version = "0.3.0-pre"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_secretbox"
-version = "0.1.1"
+version = "0.2.0-pre"
 dependencies = [
  "aead",
  "chacha20",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_secretstream"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "aead",
  "chacha20",

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_box"
-version = "0.9.1"
+version = "0.10.0-pre"
 description = """
 Pure Rust implementation of NaCl's crypto_box public-key authenticated
 encryption primitive which combines the X25519 Elliptic Curve Diffie-Hellman
@@ -19,7 +19,7 @@ rust-version = "1.85"
 
 [dependencies]
 aead = { version = "=0.6.0-rc.2", default-features = false }
-crypto_secretbox = { version = "0.1.1", default-features = false, path = "../crypto_secretbox" }
+crypto_secretbox = { version = "=0.2.0-pre", default-features = false, path = "../crypto_secretbox" }
 curve25519-dalek = { version = "=5.0.0-pre.1", default-features = false, features = ["zeroize"] }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }

--- a/crypto_kx/Cargo.toml
+++ b/crypto_kx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_kx"
-version = "0.2.1"
+version = "0.3.0-pre"
 description = "Pure Rust implementation of libsodium's crypto_kx using BLAKE2"
 authors = ["C4DT", "RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/crypto_secretbox/Cargo.toml
+++ b/crypto_secretbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_secretbox"
-version = "0.1.1"
+version = "0.2.0-pre"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption cipher as well as the libsodium variant of

--- a/crypto_secretstream/Cargo.toml
+++ b/crypto_secretstream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_secretstream"
-version = "0.2.0"
+version = "0.3.0-pre"
 description = """
 Pure Rust implementation of libsodium's crypto_secretstream secret-key using
 ChaCha20 and Poly1305


### PR DESCRIPTION
NOTE: this is not intended to have an associated crate release, just to denote that the code on `master` contains breaking changes

Bumps versions to the following:

- `crypto_box` v0.10.0-pre
- `crypto_kx` v0.3.0-pre
- `crypto_secretbox` v0.2.0-pre
- `crypto_secretstream` v0.3.0-pre