### PR TITLE
Bump `serdect` to v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "d8b59d472eab27ade8d770dcb11da7201c11234bef9f82ce7aa517be028d462b"
 
 [[package]]
 name = "base64"
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+checksum = "d3ef0e35b322ddfaecbc60f34ab448e157e48531288ee49fafbb053696b8ffe2"
 dependencies = [
  "base16ct",
  "serde",

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -28,7 +28,7 @@ zeroize = { version = "1", default-features = false }
 chacha20 = { version = "0.10.0-rc.2", optional = true }
 blake2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 salsa20 = { version = "0.11.0-rc.1", optional = true }
-serdect = { version = "0.2", optional = true, default-features = false }
+serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
 bincode = "1"

--- a/crypto_kx/Cargo.toml
+++ b/crypto_kx/Cargo.toml
@@ -19,7 +19,7 @@ curve25519-dalek = { version = "5.0.0-pre.1", default-features = false, features
 rand_core = "0.9"
 
 # optional dependencies
-serdect = { version = "0.2", optional = true, default-features = false }
+serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
 rand_core = { version = "0.9", features = ["os_rng"] }


### PR DESCRIPTION
NOTE: contains breaking changes to the wire format