### PR TITLE
crypto_box: rename `CryptoBox::new_from_clamped`

### DIFF
--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -257,12 +257,12 @@ impl<C> CryptoBox<C> {
     /// Create a new [`CryptoBox`], performing X25519 Diffie-Hellman to derive
     /// a shared secret from the provided public and secret keys.
     ///
-    /// Assumes that the scalar has alread been clamped. Eg like `ed25519-dalek` does.
-    pub fn from_clamped(public_key: &PublicKey, secret_key: &SecretKey) -> Self
+    /// Internally performs clamping.
+    pub fn new(public_key: &PublicKey, secret_key: &SecretKey) -> Self
     where
         C: Kdf,
     {
-        let shared_secret = Zeroizing::new(public_key.0 * secret_key.scalar);
+        let shared_secret = Zeroizing::new(public_key.0.mul_clamped(secret_key.bytes));
 
         // Use HChaCha20 to create a uniformly random key from the shared secret
         let key = Zeroizing::new(C::kdf((&shared_secret.0).into(), &Array::default()));
@@ -275,12 +275,12 @@ impl<C> CryptoBox<C> {
     /// Create a new [`CryptoBox`], performing X25519 Diffie-Hellman to derive
     /// a shared secret from the provided public and secret keys.
     ///
-    /// Internally performs clamping.
-    pub fn new(public_key: &PublicKey, secret_key: &SecretKey) -> Self
+    /// Assumes that the scalar has alread been clamped. Eg like `ed25519-dalek` does.
+    pub fn new_from_clamped(public_key: &PublicKey, secret_key: &SecretKey) -> Self
     where
         C: Kdf,
     {
-        let shared_secret = Zeroizing::new(public_key.0.mul_clamped(secret_key.bytes));
+        let shared_secret = Zeroizing::new(public_key.0 * secret_key.scalar);
 
         // Use HChaCha20 to create a uniformly random key from the shared secret
         let key = Zeroizing::new(C::kdf((&shared_secret.0).into(), &Array::default()));

--- a/crypto_box/tests/lib.rs
+++ b/crypto_box/tests/lib.rs
@@ -279,7 +279,7 @@ fn seal_open_roundtrip(this: &ed25519_dalek::SigningKey, other: &ed25519_dalek::
         let secret_key = crypto_box::SecretKey::from(this.to_scalar());
         let public_key = crypto_box::PublicKey::from(other.verifying_key().to_montgomery());
 
-        crypto_box::ChaChaBox::from_clamped(&public_key, &secret_key)
+        crypto_box::ChaChaBox::new_from_clamped(&public_key, &secret_key)
     };
 
     let mut sealed_message = msg.clone();
@@ -291,7 +291,7 @@ fn seal_open_roundtrip(this: &ed25519_dalek::SigningKey, other: &ed25519_dalek::
         let secret_key = crypto_box::SecretKey::from(other.to_scalar());
         let public_key = crypto_box::PublicKey::from(this.verifying_key().to_montgomery());
 
-        crypto_box::ChaChaBox::from_clamped(&public_key, &secret_key)
+        crypto_box::ChaChaBox::new_from_clamped(&public_key, &secret_key)
     };
     let mut decrypted_message = sealed_message.clone();
 


### PR DESCRIPTION
Uses a name similar to the other constructor

Also places the function after `CryptoBox::new` to give that constructor priority in e.g. rustdoc