### PR TITLE
Switch from `doc_auto_cfg` to `doc_cfg`

### DIFF
--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -52,4 +52,3 @@ serde = ["dep:serdect"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",

--- a/crypto_kx/Cargo.toml
+++ b/crypto_kx/Cargo.toml
@@ -30,4 +30,3 @@ os_rng = ["rand_core/os_rng"]
 
 [package.metadata.docs.rs]
 features = ["serde"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/crypto_kx/src/lib.rs
+++ b/crypto_kx/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"

--- a/crypto_secretbox/Cargo.toml
+++ b/crypto_secretbox/Cargo.toml
@@ -43,4 +43,3 @@ os_rng = ["aead/os_rng"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/crypto_secretbox/src/lib.rs
+++ b/crypto_secretbox/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",

--- a/crypto_secretstream/Cargo.toml
+++ b/crypto_secretstream/Cargo.toml
@@ -29,8 +29,11 @@ rand_core = { version = "0.9", features = ["std", "os_rng"] }
 
 [features]
 default = ["std", "rand_core"]
-
 alloc = ["aead/alloc"]
 std = ["alloc", "rand_core?/std"]
+
 heapless = ["aead/heapless"]
 rand_core = ["dep:rand_core"]
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
The former has been removed from the latest `nightly` compiler releases

Also removes the `--cfg docsrs` settings, since they're also automatic