### PR TITLE
Remove `bincode` dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,15 +71,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,7 +195,6 @@ name = "crypto_box"
 version = "0.10.0-pre.0"
 dependencies = [
  "aead",
- "bincode",
  "blake2",
  "chacha20",
  "crypto_secretbox",

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -31,7 +31,6 @@ salsa20 = { version = "0.11.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-bincode = "1"
 hex-literal = "0.4"
 rand = "0.9"
 rmp-serde = "1"

--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -336,54 +336,6 @@ fn get_seal_nonce(ephemeral_pk: &PublicKey, recipient_pk: &PublicKey) -> Nonce {
 mod tests {
     use super::*;
 
-    #[cfg(feature = "serde")]
-    #[test]
-    fn test_public_key_serialization() {
-        use aead::rand_core::RngCore;
-
-        // Random PK bytes
-        let mut public_key_bytes = [0; 32];
-        let mut rng = rand::rng();
-        rng.fill_bytes(&mut public_key_bytes);
-
-        // Create public key
-        let public_key = PublicKey::from(public_key_bytes);
-
-        // Round-trip serialize with bincode
-        let serialized = bincode::serialize(&public_key).unwrap();
-        let deserialized: PublicKey = bincode::deserialize(&serialized).unwrap();
-        assert_eq!(deserialized, public_key,);
-
-        // Round-trip serialize with rmp (msgpack)
-        let serialized = rmp_serde::to_vec_named(&public_key).unwrap();
-        let deserialized: PublicKey = rmp_serde::from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, public_key,);
-    }
-
-    #[cfg(feature = "serde")]
-    #[test]
-    fn test_secret_key_serialization() {
-        use aead::rand_core::RngCore;
-
-        // Random SK bytes
-        let mut secret_key_bytes = [0; 32];
-        let mut rng = rand::rng();
-        rng.fill_bytes(&mut secret_key_bytes);
-
-        // Create secret key
-        let secret_key = SecretKey::from(secret_key_bytes);
-
-        // Round-trip serialize with bincode
-        let serialized = bincode::serialize(&secret_key).unwrap();
-        let deserialized: SecretKey = bincode::deserialize(&serialized).unwrap();
-        assert_eq!(deserialized.to_bytes(), secret_key.to_bytes());
-
-        // Round-trip serialize with rmp (msgpack)
-        let serialized = rmp_serde::to_vec_named(&secret_key).unwrap();
-        let deserialized: SecretKey = rmp_serde::from_slice(&serialized).unwrap();
-        assert_eq!(deserialized.to_bytes(), secret_key.to_bytes());
-    }
-
     #[test]
     fn test_public_key_from_slice() {
         let array = [0; 40];


### PR DESCRIPTION
`bincode` is unmaintained. See https://crates.io/crates/bincode/3.0.0